### PR TITLE
Improve NativeValueComparatorGenerator.

### DIFF
--- a/compiler/codegen/src/test/java/com/asakusafw/dag/compiler/codegen/NativeValueComparatorGeneratorTest.java
+++ b/compiler/codegen/src/test/java/com/asakusafw/dag/compiler/codegen/NativeValueComparatorGeneratorTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.compiler.codegen;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.lang.compiler.common.BasicResourceContainer;
+import com.asakusafw.lang.compiler.common.Location;
+
+/**
+ * Test for {@link NativeValueComparatorGenerator}.
+ */
+public class NativeValueComparatorGeneratorTest {
+
+    /**
+     * A temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    /**
+     * copying header files.
+     */
+    @Test
+    public void copy_headers() {
+        Location base = Location.of("include");
+        BasicResourceContainer c = new BasicResourceContainer(temporary.getRoot());
+        NativeValueComparatorGenerator.copyHeaderFiles(c, base);
+        for (Location name : NativeValueComparatorGenerator.HEADER_FILE_NAMES) {
+            File f = c.toFile(base.append(name));
+            assertThat(f.isFile(), is(true));
+        }
+    }
+
+    /**
+     * copying source files.
+     */
+    @Test
+    public void copy_sources() {
+        Location base = Location.of("include");
+        BasicResourceContainer c = new BasicResourceContainer(temporary.getRoot());
+        NativeValueComparatorGenerator.copySourceFiles(c, base);
+        for (Location name : NativeValueComparatorGenerator.SOURCE_FILE_NAMES) {
+            File f = c.toFile(base.append(name));
+            assertThat(f.isFile(), is(true));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This enables to handle multiple C++ header/source files in C++ style comparator generator.
## Background, Problem or Goal of the patch

`NativeValueComparatorGenerator` has been handled only a header file `serde.hpp`, but more header/source files will be required for future enhancements.

To add header/source files, put header/source files onto `asakusa-dag-runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/{include, src}` folders.
## Design of the fix, or a new feature

This makes `NativeValueComparatorGenerator.putHeader()` deprecated, and introduce `NativeValueComparatorGenerator.copy{Header, Source}Files()` instead of the deprecated.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

N/A.
