### PR TITLE
CMake should always generate Unix Makefiles.

### DIFF
--- a/runtime/runtime/pom.xml
+++ b/runtime/runtime/pom.xml
@@ -33,6 +33,8 @@
                   <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                     <mkdir dir="${project.build.directory}/native/test/build" />
                     <exec executable="cmake" dir="${project.build.directory}/native/test/build" failonerror="true">
+                      <arg value="-G" />
+                      <arg value="Unix Makefiles" />
                       <arg value="-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}" unless:blank="${CMAKE_TOOLCHAIN_FILE}" />
                       <arg value="-DCMAKE_SKIP_RPATH=ON" />
                       <arg value="${basedir}/src/test/native" />


### PR DESCRIPTION
## Summary

Some artifacts are using `cmake` command (in tests), and they may generate platform dependent build scripts (e.g. nmake).
## Background, Problem or Goal of the patch

Using Windows, `cmake` generates build scripts for `nmake` even if cross compiling settings are enabled.
## Design of the fix, or a new feature

We explicitly put `-G "Unix Makefiles"` for each `cmake` command option.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw
