### PR TITLE
Fix C++ comparator about DecimalOptions.

### DIFF
--- a/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/NativeValueComparatorGenerator.java
+++ b/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/NativeValueComparatorGenerator.java
@@ -70,13 +70,6 @@ public class NativeValueComparatorGenerator implements Io {
 
     static final Logger LOG = LoggerFactory.getLogger(NativeValueComparatorGenerator.class);
 
-    /**
-     * The header file name.
-     * @deprecated Use {@link #copyHeaderFiles(ResourceContainer, Location)} instead.
-     */
-    @Deprecated
-    public static final String HEADER_FILE_NAME = "serde.hpp";
-
     static final Charset ENCODE = StandardCharsets.UTF_8;
 
     private static final Location ATTACHED_BASE = Location.of("com/asakusafw/dag/runtime/io/native"); //$NON-NLS-1$
@@ -87,6 +80,7 @@ public class NativeValueComparatorGenerator implements Io {
 
     static final Set<Location> HEADER_FILE_NAMES = Stream.of(new String[] {
             "serde.hpp", //$NON-NLS-1$
+            "mpdecimal.hpp", //$NON-NLS-1$
     })
             .map(Location::of)
             .collect(Collectors.collectingAndThen(
@@ -94,15 +88,12 @@ public class NativeValueComparatorGenerator implements Io {
                     Collections::unmodifiableSet));
 
     static final Set<Location> SOURCE_FILE_NAMES = Stream.of(new String[] {
-            // empty files
+            "mpdecimal.cpp", //$NON-NLS-1$
     })
             .map(Location::of)
             .collect(Collectors.collectingAndThen(
                     Collectors.toSet(),
                     Collections::unmodifiableSet));
-
-    static final Location HEADER_PATH =
-            Location.of("com/asakusafw/dag/runtime/io/native/include/serde.hpp"); //$NON-NLS-1$
 
     private static final Pattern PATTERN_VARIABLE = Pattern.compile("\\$\\{(\\w+)\\}"); //$NON-NLS-1$
 
@@ -279,28 +270,6 @@ public class NativeValueComparatorGenerator implements Io {
             throw new IllegalStateException(MessageFormat.format(
                     "error occurred while copying file: {0} -> {1}",
                     src, dst), e);
-        }
-    }
-
-    /**
-     * Puts header file contents into the target writer.
-     * @param writer the target writer
-     * @deprecated Use {@link #copySourceFiles(ResourceContainer, Location)} and
-     *     {@link #copySourceFiles(ResourceContainer, Location)} instead
-     */
-    @Deprecated
-    public static void putHeader(PrintWriter writer) {
-        try (InputStream in = ValueOptionSerDe.class.getClassLoader().getResourceAsStream(HEADER_PATH.toPath())) {
-            Invariants.requireNonNull(in);
-            try (Scanner s = new Scanner(new InputStreamReader(in, ENCODE))) {
-                while (s.hasNextLine()) {
-                    writer.println(s.nextLine());
-                }
-            }
-        } catch (IOException e) {
-            throw new IllegalStateException(MessageFormat.format(
-                    "error occurred while copying header file: {0}",
-                    HEADER_PATH), e);
         }
     }
 }

--- a/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/include/mpdecimal.hpp
+++ b/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/include/mpdecimal.hpp
@@ -1,0 +1,497 @@
+/*
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef ASAKUSAFW_MPDECIMAL_HPP
+#define ASAKUSAFW_MPDECIMAL_HPP
+
+#include <vector>
+#include <cstddef>
+#include <cstdint>
+
+namespace asakusafw {
+namespace math {
+
+/*
+ * \brief Represents a comparing two values.
+ */
+enum class Sign : int {
+
+    /*
+     * \brief the first one is less than the second one.
+     */
+    less_than = -1,
+
+    /*
+     * \brief both are equivalent.
+     */
+    equal_to = 0,
+
+    /*
+     * \brief the first one is greater than the second one.
+     */
+    greater_than = +1,
+};
+
+/*
+ * \brief Returns a negated sign value.
+ * \param sign the original sign value
+ * \return the negated sign value
+ */
+inline
+Sign negate(Sign sign) {
+    return static_cast<Sign>(-static_cast<int>(sign));
+}
+
+class MpInt;
+class CompactDecimal;
+class MpDecimal;
+
+/*
+ * \brief A simple multi-precision unsigned integer.
+ */
+class MpInt {
+public:
+    /*
+     * \brief The default constructor.
+     * The created object will just represents zero.
+     */
+    MpInt() = default;
+
+    /*
+     * \brief The destructor.
+     */
+    ~MpInt() = default;
+
+    /*
+     * \brief A constructor.
+     * \param value the integer
+     */
+    MpInt(uint64_t value);
+
+    /*
+     * \brief A constructor.
+     * \param bytes the binary integer, in network byte order
+     * \param length the byte length of binary integer
+     */
+    MpInt(const uint8_t *bytes, std::size_t length);
+
+    /*
+     * \brief The copy constructor.
+     * \param other the source object
+     */
+    MpInt(const MpInt& other) = default;
+
+    /*
+     * \brief The move constructor.
+     * \param other the source object
+     */
+    MpInt(MpInt&& other) noexcept = default;
+
+    MpInt& operator=(const MpInt&) = delete;
+    MpInt& operator=(MpInt&&) noexcept = delete;
+
+    /**
+     * \brief Returns the number of available bits.
+     * \return the number of available bits
+     */
+    std::size_t bits() const;
+
+    /**
+     * \brief Returns a copy of bytes, as the network byte order.
+     * \return a copy of bytes as network byte order
+     */
+    std::vector<uint8_t> data() const;
+
+    /**
+     * \brief Compares this to another integer.
+     * \param other another integer
+     * \return less_than - if this is less than another,
+     *     equal_to - if this and another are equivalent,
+     *     greater_than - otherwise
+     */
+    Sign compare_to(uint64_t other) const;
+
+    /**
+     * \brief Compares this to another multi-precision integer.
+     * \param other another integer
+     * \return less_than - if this is less than another,
+     *     equal_to - if this and another are equivalent,
+     *     greater_than - otherwise
+     */
+    Sign compare_to(const MpInt& other) const;
+
+    /**
+     * \brief Returns 10^{exponent}.
+     * \param exponent the exponent
+     * \return 10^{exponent} as a multi-precision integer
+     */
+    static
+    const MpInt& power_of_10(uint32_t exponent);
+
+    /*
+     * \brief Returns whether or not this and another integer are equivalent.
+     * \param other another integer
+     * \return true if both are equivalent, otherwise false
+     */
+    inline
+    bool operator==(const MpInt& other) const {
+        return m_members == other.m_members;
+    }
+
+    /*
+     * \brief Returns whether or not this and another integer are NOT equivalent.
+     * \param other another integer
+     * \return true if both are NOT equivalent, otherwise false
+     */
+    inline
+    bool operator!=(const MpInt& other) const {
+        return !(*this == other);
+    }
+
+    /*
+     * \brief Returns whether or not this and another integer are equivalent.
+     * \param other another integer
+     * \return true if both are equivalent, otherwise false
+     */
+    inline
+    bool operator==(uint64_t other) const {
+        if (m_members.empty()) {
+            return other == 0ULL;
+        } else if (other == 0ULL) {
+            return false;
+        } else if (m_members.size() == 1) {
+            return m_members.front() == other;
+        } else if (m_members.size() == 2) {
+            return m_members[0] == static_cast<uint32_t>(other)
+                    && m_members[1] == static_cast<uint32_t>(other >> 32);
+        } else {
+            return false;
+        }
+    }
+
+    /*
+     * \brief Returns whether or not this and another integer are NOT equivalent.
+     * \param other another integer
+     * \return true if both are NOT equivalent, otherwise false
+     */
+    inline
+    bool operator!=(uint64_t other) const {
+        return !(*this == other);
+    }
+
+    /*
+     * \brief Returns whether or not the two integers are equivalent.
+     * \param a the first integer
+     * \param b the second integer
+     * \return true if both are equivalent, otherwise false
+     */
+    inline
+    friend bool operator==(uint64_t a, const MpInt& b) {
+        return b == a;
+    }
+
+    /*
+     * \brief Returns whether or not the two integers are NOT equivalent.
+     * \param a the first integer
+     * \param b the second integer
+     * \return true if both are NOT equivalent, otherwise false
+     */
+    inline
+    friend bool operator!=(uint64_t a, const MpInt& b) {
+        return !(a == b);
+    }
+
+    /*
+     * \brief Returns the product of this and the multiplier.
+     * \param multiplier the multiplier
+     * \return the product
+     */
+    MpInt operator*(const MpInt& multiplier) const;
+
+    /*
+     * \brief Returns the product of this and the multiplier.
+     * \param multiplier the multiplier
+     * \return the product
+     */
+    MpInt operator*(uint32_t multiplier) const;
+
+    /*
+     * \brief Returns the product of the two integers.
+     * \param a the multiplicand
+     * \param a the multiplier
+     * \return the product
+     */
+    inline
+    friend MpInt operator*(uint32_t a, const MpInt& b) {
+        return b * a;
+    }
+
+private:
+    MpInt(const std::vector<uint32_t>& members);
+    MpInt(std::vector<uint32_t>&& members);
+    std::vector<uint32_t> m_members;
+};
+
+/*
+ * \brief A simple compact unsigned decimal.
+ * This only can represent [0, 2^{64}).
+ */
+class CompactDecimal {
+public:
+    /*
+     * \brief The default constructor.
+     * The created object will just represents zero.
+     */
+    CompactDecimal() = default;
+
+    /*
+     * \brief The destructor.
+     */
+    ~CompactDecimal() = default;
+
+    /*
+     * \brief The copy constructor.
+     * \param other the source object
+     */
+    CompactDecimal(const CompactDecimal& other) = default;
+
+    /*
+     * \brief The move constructor.
+     * \param other the source object
+     */
+    CompactDecimal(CompactDecimal&& other) noexcept = default;
+
+    CompactDecimal& operator=(const CompactDecimal&) = delete;
+    CompactDecimal& operator=(CompactDecimal&&) noexcept = delete;
+
+    /*
+     * \brief A constructor.
+     * \param significand the significand
+     * \param exponent the ten's exponent
+     */
+    CompactDecimal(uint64_t significand, int32_t exponent)
+            : m_significand(significand)
+            , m_exponent(exponent) {};
+
+    /*
+     * \brief Returns the significand.
+     * \return the significand
+     */
+    inline
+    uint64_t significand() const {
+        return m_significand;
+    }
+
+    /*
+     * \brief Returns the ten's exponent.
+     * \return the exponent
+     */
+    inline
+    int32_t exponent() const {
+        return m_exponent;
+    }
+
+    /*
+     * \brief Compares this with another decimal.
+     * \param other another decimal
+     * \return less_than - if this is less than another,
+     *     equal_to - if this and another are equivalent,
+     *     greater_than - otherwise
+     */
+    Sign compare_to(const CompactDecimal& other) const;
+
+    /*
+     * \brief Compares this with another decimal.
+     * \param other another decimal
+     * \return less_than - if this is less than another,
+     *     equal_to - if this and another are equivalent,
+     *     greater_than - otherwise
+     */
+    Sign compare_to(const MpDecimal& other) const;
+
+private:
+    const uint64_t m_significand;
+    const int32_t m_exponent;
+};
+
+/*
+ * \brief A simple multi-precision unsigned decimal.
+ */
+class MpDecimal {
+public:
+    /*
+     * \brief The default constructor.
+     * The created object will just represents zero.
+     */
+    MpDecimal() = default;
+
+    /*
+     * \brief The destructor.
+     */
+    ~MpDecimal() = default;
+
+    /*
+     * \brief The copy constructor.
+     * \param other the source object
+     */
+    MpDecimal(const MpDecimal& other) = default;
+
+    /*
+     * \brief The move constructor.
+     * \param other the source object
+     */
+    MpDecimal(MpDecimal&& other) noexcept
+            : m_significand(std::move(other.m_significand))
+            , m_exponent(other.m_exponent) {};
+
+    MpDecimal& operator=(const MpDecimal&) = delete;
+    MpDecimal& operator=(MpDecimal&&) noexcept = delete;
+
+    /*
+     * \brief A constructor.
+     * \param bytes the binary integer of significand, in network byte order
+     * \param length the byte length of binary integer
+     * \param exponent the ten's exponent
+     */
+    MpDecimal(const uint8_t *bytes, std::size_t length, int32_t exponent)
+            : m_significand(bytes, length)
+            , m_exponent(exponent) {};
+
+    /*
+     * \brief A constructor.
+     * \param significand the significand
+     * \param exponent the ten's exponent
+     */
+    MpDecimal(const MpInt& significand, int32_t exponent)
+            : m_significand(significand)
+            , m_exponent(exponent) {};
+
+    /*
+     * \brief A constructor.
+     * \param significand the significand
+     * \param exponent the ten's exponent
+     */
+    MpDecimal(MpInt&& significand, int32_t exponent)
+            : m_significand(std::move(significand))
+            , m_exponent(exponent) {};
+
+    /*
+     * \brief Returns the significand.
+     * \return the significand
+     */
+    inline
+    const MpInt& significand() const {
+        return m_significand;
+    }
+
+    /*
+     * \brief Returns the ten's exponent.
+     * \return the exponent
+     */
+    inline
+    int32_t exponent() const {
+        return m_exponent;
+    };
+
+    /*
+     * \brief Compares this with another decimal.
+     * \param other another decimal
+     * \return less_than - if this is less than another,
+     *     equal_to - if this and another are equivalent,
+     *     greater_than - otherwise
+     */
+    Sign compare_to(const CompactDecimal& other) const;
+
+    /*
+     * \brief Compares this with another decimal.
+     * \param other another decimal
+     * \return less_than - if this is less than another,
+     *     equal_to - if this and another are equivalent,
+     *     greater_than - otherwise
+     */
+    Sign compare_to(const MpDecimal& other) const;
+
+private:
+    const MpInt m_significand;
+    const int32_t m_exponent;
+};
+
+/*
+ * \brief Compares two decimals.
+ * \param a_buf the binary integer of significand in the first decimal, in network byte order
+ * \param a_length the byte length of binary integer in the first decimal
+ * \param a_exponent the ten's exponent in the first decimal
+ * \param b_buf the binary integer of significand in the second decimal, in network byte order
+ * \param b_length the byte length of binary integer in the second decimal
+ * \param b_exponent the ten's exponent in the second decimal
+ * \return less_than - if the first one is less than the second one,
+ *     equal_to - if the two decimals are equivalent,
+ *     greater_than - otherwise
+ */
+Sign compare_decimal(
+        const uint8_t *a_buf, std::size_t a_length, int32_t a_exponent,
+        const uint8_t *b_buf, std::size_t b_length, int32_t b_exponent);
+
+/*
+ * \brief Compares two decimals.
+ * \param a_buf the binary integer of significand in the first decimal, in network byte order
+ * \param a_length the byte length of binary integer in the first decimal
+ * \param a_exponent the ten's exponent in the first decimal
+ * \param b_significand the significand in the second decimal
+ * \param b_exponent the ten's exponent in the second decimal
+ * \return less_than - if the first one is less than the second one,
+ *     equal_to - if the two decimals are equivalent,
+ *     greater_than - otherwise
+ */
+Sign compare_decimal(
+        const uint8_t *a_buf, std::size_t a_length, int32_t a_exponent,
+        uint64_t b_significand, int32_t b_exponent);
+
+/*
+ * \brief Compares two decimals.
+ * \param a_significand the significand in the first decimal
+ * \param a_exponent the ten's exponent in the first decimal
+ * \param b_buf the binary integer of significand in the second decimal, in network byte order
+ * \param b_length the byte length of binary integer in the second decimal
+ * \param b_exponent the ten's exponent in the second decimal
+ * \return less_than - if the first one is less than the second one,
+ *     equal_to - if the two decimals are equivalent,
+ *     greater_than - otherwise
+ */
+inline
+Sign compare_decimal(
+        uint64_t a_significand, int32_t a_exponent,
+        const uint8_t *b_buf, std::size_t b_length, int32_t b_exponent) {
+    return negate(compare_decimal(b_buf, b_length, b_exponent, a_significand, a_exponent));
+}
+
+/*
+ * \brief Compares two decimals.
+ * \param a_significand the significand in the first decimal
+ * \param a_exponent the ten's exponent in the first decimal
+ * \param b_significand the significand in the second decimal
+ * \param b_exponent the ten's exponent in the second decimal
+ * \return less_than - if the first one is less than the second one,
+ *     equal_to - if the two decimals are equivalent,
+ *     greater_than - otherwise
+ */
+Sign compare_decimal(
+        uint64_t a_significand, int32_t a_exponent,
+        uint64_t b_significand, int32_t b_exponent);
+
+} // namespace math
+} // namespace asakusafw
+
+#endif // ASAKUSAFW_MPDECIMAL_HPP

--- a/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/include/serde.hpp
+++ b/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/include/serde.hpp
@@ -16,10 +16,13 @@
 #ifndef ASAKUSAFW_SERDE_HPP
 #define ASAKUSAFW_SERDE_HPP
 
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <algorithm>
 #include <stdexcept>
+#include "mpdecimal.hpp"
 
 namespace asakusafw {
 namespace serde {
@@ -48,12 +51,12 @@ T read_value(int8_t *&p) {
 
 static
 inline
-size_t compact_int_size(int8_t head) {
+std::size_t compact_int_size(int8_t head) {
     if (head >= COMPACT_INT_HEAD_MIN) {
         return 1;
     }
     auto scale = COMPACT_INT_HEAD_MIN - head;
-    return static_cast<size_t>(1 << (scale - 1)) + 1;
+    return static_cast<std::size_t>(1 << (scale - 1)) + 1;
 }
 
 static
@@ -185,7 +188,7 @@ int compare_string(int8_t *&a, int8_t *&b) {
     } else if (len_b < 0) {
         return +1;
     }
-    int diff = memcmp(a, b, static_cast<size_t>(std::min(len_a, len_b)));
+    int diff = memcmp(a, b, static_cast<std::size_t>(std::min(len_a, len_b)));
     if (diff != 0) {
         return diff;
     }
@@ -199,45 +202,6 @@ const static int8_t DECIMAL_PLUS_MASK = 1 << 1;
 const static int8_t DECIMAL_COMPACT_MASK = 1 << 2;
 
 static
-int compare_compact_decimal(
-        int32_t scale_a, int64_t unscaled_a,
-        int32_t scale_b, int64_t unscaled_b) {
-    if (scale_a == scale_b) {
-        return compare_value(unscaled_a, unscaled_b);
-    }
-    if (unscaled_a == 0) {
-        if (unscaled_b == 0) {
-            return 0;
-        } else {
-            return -1;
-        }
-    } else if (unscaled_b == 0) {
-        return +1;
-    }
-    if (scale_a > scale_b) {
-        auto scale = scale_a - scale_b;
-        auto current = unscaled_a;
-        bool rest = false;
-        for (int32_t i = 0; i < scale; i++) {
-            auto next = current / 10;
-            rest |= (current % 10 != 0);
-            if (next == 0) {
-                return -1;
-            }
-            current = next;
-        }
-        int diff = compare_value(current, unscaled_b);
-        if (diff == 0) {
-            return rest ? +1 : 0;
-        }
-        return diff;
-    } else /*if (scale_a < scale_b)*/ {
-        return -compare_compact_decimal(scale_b, unscaled_b, scale_a, unscaled_a);
-    }
-}
-
-static
-inline
 int compare_decimal(int8_t *&a, int8_t *&b) {
     auto head_a = read_value<int8_t>(a);
     auto head_b = read_value<int8_t>(b);
@@ -250,33 +214,50 @@ int compare_decimal(int8_t *&a, int8_t *&b) {
     } else if (head_b == DECIMAL_NULL) {
         return +1;
     }
-    auto plus_a = (head_a & DECIMAL_PLUS_MASK) != 0;
-    auto plus_b = (head_b & DECIMAL_PLUS_MASK) != 0;
+    bool plus_a = (head_a & DECIMAL_PLUS_MASK) != 0;
+    bool plus_b = (head_b & DECIMAL_PLUS_MASK) != 0;
     if (plus_a != plus_b) {
-        if (plus_a) {
-            return +1;
-        } else {
-            return -1;
-        }
+        return plus_a ? +1 : -1;
     }
-    auto compact_a = (head_a & DECIMAL_COMPACT_MASK) != 0;
-    auto compact_b = (head_b & DECIMAL_COMPACT_MASK) != 0;
-    auto scale_a = static_cast<int32_t>(read_compact_int(a));
-    auto scale_b = static_cast<int32_t>(read_compact_int(b));
+    bool compact_a = (head_a & DECIMAL_COMPACT_MASK) != 0;
+    bool compact_b = (head_b & DECIMAL_COMPACT_MASK) != 0;
+    int32_t scale_a = static_cast<int32_t>(read_compact_int(a));
+    int32_t scale_b = static_cast<int32_t>(read_compact_int(b));
+    int64_t unscaled_a = read_compact_int(a);
+    int64_t unscaled_b = read_compact_int(b);
+    assert(unscaled_a >= 0);
+    assert(unscaled_b >= 0);
+    asakusafw::math::Sign sign;
     if (compact_a && compact_b) {
-        auto unscaled_a = read_compact_int(a);
-        auto unscaled_b = read_compact_int(b);
-        auto diff = compare_compact_decimal(scale_a, unscaled_a, scale_b, unscaled_b);
-        return plus_a ? diff : -diff;
-    }
-    // FIXME simple impl
-    if (compact_a) {
-        return -1;
+        sign = asakusafw::math::compare_decimal(
+                static_cast<uint64_t>(unscaled_a), -scale_a,
+                static_cast<uint64_t>(unscaled_b), -scale_b);
+    } else if (compact_a) {
+        const uint8_t *b_buf = reinterpret_cast<uint8_t*>(b);
+        std::size_t b_length = static_cast<std::size_t>(unscaled_b);
+        b += b_length;
+        sign = asakusafw::math::compare_decimal(
+                static_cast<uint64_t>(unscaled_a), -scale_a,
+                b_buf, b_length, -scale_b);
     } else if (compact_b) {
-        return +1;
+        const uint8_t *a_buf = reinterpret_cast<uint8_t*>(a);
+        std::size_t a_length = static_cast<std::size_t>(unscaled_a);
+        a += a_length;
+        sign = asakusafw::math::compare_decimal(
+                a_buf, a_length, -scale_a,
+                static_cast<uint64_t>(unscaled_b), -scale_b);
     } else {
-        return 0;
+        const uint8_t *a_buf = reinterpret_cast<uint8_t*>(a);
+        std::size_t a_length = static_cast<std::size_t>(unscaled_a);
+        a += a_length;
+        const uint8_t *b_buf = reinterpret_cast<uint8_t*>(b);
+        std::size_t b_length = static_cast<std::size_t>(unscaled_b);
+        b += b_length;
+        sign = asakusafw::math::compare_decimal(
+                a_buf, a_length, -scale_a,
+                b_buf, b_length, -scale_b);
     }
+    return static_cast<int>(plus_a ? sign : asakusafw::math::negate(sign));
 }
 
 template<typename T>

--- a/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/src/mpdecimal.cpp
+++ b/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/src/mpdecimal.cpp
@@ -1,0 +1,577 @@
+/*
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mpdecimal.hpp"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <cmath>
+#include <array>
+#include <vector>
+#include <tuple>
+#include <mutex>
+#include <algorithm>
+
+#define RETURN_IF_DIFFERENT(diff) \
+{\
+    Sign _difference = (diff);\
+    if (_difference != Sign::equal_to) return _difference;\
+}
+
+using namespace asakusafw::math;
+
+inline
+static std::size_t count_leading_zero_bits(uint32_t value) {
+    if (value == 0) {
+        return 32;
+    }
+    uint32_t v = value;
+    std::size_t result = 0;
+    if ((v & UINT32_C(0xffff0000)) == 0) {
+        result += 16;
+    } else {
+        v >>= 16;
+    }
+    if ((v & UINT32_C(0xff00)) == 0) {
+        result += 8;
+    } else {
+        v >>= 8;
+    }
+    if ((v & UINT32_C(0xf0)) == 0) {
+        result += 4;
+    } else {
+        v >>= 4;
+    }
+    if ((v & UINT32_C(0xc)) == 0) {
+        result += 2;
+    } else {
+        v >>= 2;
+    }
+    if ((v & UINT32_C(0x2)) == 0) {
+        result += 1;
+    }
+    assert(result < 32);
+    return result;
+}
+
+template<typename T>
+inline
+static T get_uint(const uint8_t *bytes, std::size_t count) {
+    assert(0 <= count);
+    assert(count <= sizeof(T));
+    T result = 0;
+    for (int i = 0; i < count; i++) {
+        result = result << 8 | bytes[i];
+    }
+    return result;
+}
+
+inline
+static void shrink_vector(std::vector<uint32_t>& vector) {
+    while (!vector.empty() && vector.back() == 0) {
+        vector.pop_back();
+    }
+    assert(vector.empty() || vector.back() != 0);
+}
+
+MpInt::MpInt(uint64_t value) {
+    if (value != 0) {
+        m_members.reserve(2);
+        m_members.push_back(static_cast<uint32_t>(value));
+        uint32_t hi = static_cast<uint32_t>(value >> 32);
+        if (hi != 0) {
+            m_members.push_back(hi);
+        }
+    }
+    assert(m_members.empty() || m_members.back() != 0);
+}
+
+MpInt::MpInt(const uint8_t *bytes, std::size_t size_in_bytes) {
+    // skip leading zeros
+    const uint8_t *buf = bytes;
+    std::size_t len = size_in_bytes;
+    while (len > 0) {
+        if (*buf != 0) {
+            break;
+        }
+        buf++;
+        len--;
+    }
+    if (len != 0) {
+        std::size_t blocks = (len + (sizeof(uint32_t) - 1)) / sizeof(uint32_t);
+        m_members.reserve(blocks);
+        while (len >= sizeof(uint32_t)) {
+            len -= sizeof(uint32_t);
+            m_members.push_back(get_uint<uint32_t>(buf + len, sizeof(uint32_t)));
+        }
+        if (len != 0) {
+            m_members.push_back(get_uint<uint32_t>(buf, len));
+        }
+    }
+    assert(m_members.empty() || m_members.back() != 0);
+}
+
+MpInt::MpInt(const std::vector<uint32_t>& members) : m_members(members) {
+    shrink_vector(m_members);
+}
+
+MpInt::MpInt(std::vector<uint32_t>&& members) : m_members(members) {
+    shrink_vector(m_members);
+}
+
+std::size_t MpInt::bits() const {
+    assert(m_members.empty() || m_members.back() != 0);
+    if (m_members.empty()) {
+        return 0;
+    } else {
+        std::size_t block_bits = m_members.size() * 32;
+        std::size_t zero_bits = count_leading_zero_bits(m_members.back());
+        assert(zero_bits < 32); // the last word must not be zero
+        return block_bits - zero_bits;
+    }
+}
+
+std::vector<uint8_t> MpInt::data() const {
+    std::size_t size = (bits() + 7) / 8;
+    if (size == 0) {
+        return std::vector<uint8_t>(0);
+    }
+    assert(!m_members.empty());
+    std::vector<uint8_t> results;
+    results.reserve(size);
+    int first_size = size % sizeof(uint32_t);
+    bool first = first_size != 0;
+    for (auto itr = m_members.rbegin(); itr != m_members.rend(); ++itr) {
+        uint32_t value = *itr;
+        if (first) {
+            assert(value != 0);
+            for (int i = first_size - 1; i >= 0; i--) {
+                results.push_back(static_cast<uint8_t>(value >> (i * 8)));
+            }
+            first = false;
+        } else {
+            results.push_back(static_cast<uint8_t>(value >> 24));
+            results.push_back(static_cast<uint8_t>(value >> 16));
+            results.push_back(static_cast<uint8_t>(value >>  8));
+            results.push_back(static_cast<uint8_t>(value >>  0));
+        }
+    }
+    assert(results.size() == size);
+    assert(results.front() != 0);
+    return results;
+}
+
+MpInt MpInt::operator*(uint32_t multiplier) const {
+    if (multiplier == 0) {
+        return MpInt();
+    } else if (multiplier == 1) {
+        return *this;
+    }
+    std::size_t current_bits = bits();
+    if (current_bits == 0) {
+        return MpInt();
+    } else if (current_bits == 1) {
+        return MpInt(static_cast<uint64_t>(multiplier));
+    }
+    std::size_t result_bits = current_bits + 32 - count_leading_zero_bits(multiplier);
+    std::vector<uint32_t> results;
+    results.reserve((result_bits + 31) / 32);
+
+    uint64_t work = 0;
+    for (auto itr = m_members.begin(); itr != m_members.end(); ++itr) {
+        work += static_cast<uint64_t>(*itr) * multiplier;
+        results.push_back(static_cast<uint32_t>(work));
+        work >>= 32; // carry-up
+    }
+    if (work != 0) {
+        results.push_back(static_cast<uint32_t>(work));
+    }
+    return MpInt(std::move(results));
+}
+
+MpInt MpInt::operator*(const MpInt& multiplier) const {
+    if (m_members.empty() || multiplier.m_members.empty()) {
+        return MpInt();
+    }
+    std::size_t a_size = m_members.size();
+    std::size_t b_size = multiplier.m_members.size();
+    if (a_size > b_size) {
+        return multiplier * *this;
+    }
+    std::size_t current_bits = bits();
+    if (current_bits == 1) {
+        return multiplier;
+    }
+    std::size_t other_bits = multiplier.bits();
+    if (other_bits == 1) {
+        return *this;
+    }
+    std::size_t result_bits = current_bits + other_bits;
+    std::vector<uint32_t> results((result_bits + 31) / 32, 0);
+    std::size_t c_size = results.size();
+    for (std::size_t i = 0; i < a_size; i++) {
+        uint64_t a = static_cast<uint64_t>(m_members[i]);
+        uint64_t work = 0;
+        for (std::size_t j = 0; j < b_size; j++) {
+            assert(work <= UINT64_C(0xffffffff));
+            uint64_t b = static_cast<uint64_t>(multiplier.m_members[j]);
+            int k = i + j;
+            uint32_t &c = results[k];
+            work += a * b + c;
+            c = static_cast<uint32_t>(work);
+            work >>= 32;
+        }
+        for (std::size_t j = b_size; j < c_size; j++) {
+            if (work == 0) {
+                break;
+            }
+            assert(work <= UINT64_C(0xffffffff));
+            int k = i + j;
+            uint32_t &c = results[k];
+            work += c;
+            c = static_cast<uint32_t>(work);
+            work >>= 32;
+        }
+        assert(work == 0);
+    }
+    return MpInt(std::move(results));
+}
+
+template<typename T>
+inline
+static Sign compare_value(T a, T b) {
+    return a == b ? Sign::equal_to : a < b ? Sign::less_than : Sign::greater_than;
+}
+
+inline
+static Sign compare_memory(
+        const uint8_t *a_buf, std::size_t a_length,
+        const uint8_t *b_buf, std::size_t b_length) {
+    std::size_t length = std::min(a_length, b_length);
+    if (length != 0) {
+        int diff = memcmp(a_buf, b_buf, length);
+        RETURN_IF_DIFFERENT(compare_value(diff, 0));
+    }
+    RETURN_IF_DIFFERENT(compare_value(a_length, b_length));
+    return Sign::equal_to;
+}
+
+Sign MpInt::compare_to(uint64_t other) const {
+    std::size_t words = m_members.size();
+    if (words == 0) {
+        return compare_value(UINT64_C(0), other);
+    }
+    if (words == 1) {
+        RETURN_IF_DIFFERENT(compare_value(UINT32_C(0), static_cast<uint32_t>(other >> 32)));
+        RETURN_IF_DIFFERENT(compare_value(m_members[0], static_cast<uint32_t>(other)));
+        return Sign::equal_to;
+    }
+    if (words == 2) {
+        RETURN_IF_DIFFERENT(compare_value(m_members[1], static_cast<uint32_t>(other >> 32)));
+        RETURN_IF_DIFFERENT(compare_value(m_members[0], static_cast<uint32_t>(other)));
+        return Sign::equal_to;
+    }
+    return Sign::greater_than;
+}
+
+Sign MpInt::compare_to(const MpInt& other) const {
+    RETURN_IF_DIFFERENT(compare_value(bits(), other.bits()));
+    assert(m_members.size() == other.m_members.size());
+    for (auto itr_a = m_members.rbegin(), itr_b = other.m_members.rbegin();
+            itr_a != m_members.rend();
+            ++itr_a, ++itr_b) {
+        assert(itr_b != other.m_members.rend());
+        RETURN_IF_DIFFERENT(compare_value(*itr_a, *itr_b));
+    }
+    return Sign::equal_to;
+}
+
+static
+const std::array<uint64_t, 20> s_compact_exponents({{
+    UINT64_C(1),
+    UINT64_C(10),
+    UINT64_C(100),
+    UINT64_C(1000),
+    UINT64_C(10000),
+    UINT64_C(100000),
+    UINT64_C(1000000),
+    UINT64_C(10000000),
+    UINT64_C(100000000),
+    UINT64_C(1000000000),
+    UINT64_C(10000000000),
+    UINT64_C(100000000000),
+    UINT64_C(1000000000000),
+    UINT64_C(10000000000000),
+    UINT64_C(100000000000000),
+    UINT64_C(1000000000000000),
+    UINT64_C(10000000000000000),
+    UINT64_C(100000000000000000),
+    UINT64_C(1000000000000000000),
+    UINT64_C(10000000000000000000), // requires just 64-bits
+}});
+
+static std::mutex s_exponents_table_mutex;
+static std::vector<MpInt*> s_exponents_table;
+
+const MpInt& MpInt::power_of_10(uint32_t exponent) {
+    // Elements of s_exponents_table must be thread-safe.
+    // To prevent from re-allocating MpInt, vector element must be a pointer
+    std::lock_guard<std::mutex> lock(s_exponents_table_mutex);
+    if (exponent >= s_exponents_table.size()) {
+        if (s_exponents_table.empty()) {
+            s_exponents_table.reserve(std::max(UINT32_C(64), exponent + 1));
+            for (uint64_t compact : s_compact_exponents) {
+                s_exponents_table.push_back(new MpInt(compact));
+            }
+        }
+        assert(s_exponents_table.size() >= 1);
+        MpInt *last = s_exponents_table.back();
+        for (std::size_t i = s_exponents_table.size(); i <= exponent; i++) {
+            MpInt *next = new MpInt(*last * 10);
+            s_exponents_table.push_back(next);
+            last = next;
+        }
+    }
+    assert(exponent < s_exponents_table.size());
+    return *s_exponents_table[exponent];
+}
+
+static
+Sign compare_with_exponent(uint64_t a, uint64_t b, uint32_t exponent);
+
+static
+Sign compare_with_exponent(const MpInt& a, uint64_t b, uint32_t exponent);
+
+static
+Sign compare_with_exponent(uint64_t a, const MpInt& b, uint32_t exponent);
+
+static
+Sign compare_with_exponent(const MpInt& a, const MpInt& b, uint32_t exponent);
+
+Sign CompactDecimal::compare_to(const CompactDecimal& other) const {
+    uint64_t a = significand();
+    uint64_t b = other.significand();
+    int32_t a_exponent = exponent();
+    int32_t b_exponent = other.exponent();
+    if (a_exponent == b_exponent) {
+        return compare_value(a, b);
+    } else if (a_exponent < b_exponent) {
+        uint32_t exponent = static_cast<uint32_t>(b_exponent - a_exponent);
+        return compare_with_exponent(a, b, exponent);
+    } else {
+        assert(a_exponent > b_exponent);
+        uint32_t exponent = static_cast<uint32_t>(a_exponent - b_exponent);
+        return negate(compare_with_exponent(b, a, exponent));
+    }
+}
+
+Sign CompactDecimal::compare_to(const MpDecimal& other) const {
+    return negate(other.compare_to(*this));
+}
+
+Sign MpDecimal::compare_to(const CompactDecimal& other) const {
+    const MpInt &a = significand();
+    uint64_t b = other.significand();
+    int32_t a_exponent = exponent();
+    int32_t b_exponent = other.exponent();
+    if (a_exponent == b_exponent) {
+        return significand().compare_to(other.significand());
+    } else if (a_exponent < b_exponent) {
+        uint32_t exponent = static_cast<uint32_t>(b_exponent - a_exponent);
+        return compare_with_exponent(a, b, exponent);
+    } else {
+        assert(a_exponent > b_exponent);
+        uint32_t exponent = static_cast<uint32_t>(a_exponent - b_exponent);
+        return negate(compare_with_exponent(b, a, exponent));
+    }
+}
+
+Sign MpDecimal::compare_to(const MpDecimal& other) const {
+    const MpInt &a = significand();
+    const MpInt &b = other.significand();
+    int32_t a_exponent = exponent();
+    int32_t b_exponent = other.exponent();
+    if (a_exponent == b_exponent) {
+        return significand().compare_to(other.significand());
+    } else if (a_exponent < b_exponent) {
+        uint32_t exponent = static_cast<uint32_t>(b_exponent - a_exponent);
+        return compare_with_exponent(a, b, exponent);
+    } else {
+        assert(a_exponent > b_exponent);
+        uint32_t exponent = static_cast<uint32_t>(a_exponent - b_exponent);
+        return negate(compare_with_exponent(b, a, exponent));
+    }
+}
+
+Sign asakusafw::math::compare_decimal(
+        const uint8_t *a_buf, std::size_t a_length, int32_t a_exponent,
+        const uint8_t *b_buf, std::size_t b_length, int32_t b_exponent) {
+    if (a_exponent == b_exponent) {
+        return compare_memory(a_buf, a_length, b_buf, b_length);
+    }
+    MpDecimal a(a_buf, a_length, a_exponent);
+    MpDecimal b(b_buf, b_length, b_exponent);
+    return a.compare_to(b);
+}
+
+Sign asakusafw::math::compare_decimal(
+        const uint8_t *a_buf, std::size_t a_length, int32_t a_exponent,
+        uint64_t b_significand, int32_t b_exponent) {
+    MpDecimal a(a_buf, a_length, a_exponent);
+    CompactDecimal b(b_significand, b_exponent);
+    return a.compare_to(b);
+}
+
+Sign asakusafw::math::compare_decimal(
+        uint64_t a_significand, int32_t a_exponent,
+        uint64_t b_significand, int32_t b_exponent) {
+    if (a_exponent == b_exponent) {
+        return compare_value(a_significand, b_significand);
+    }
+    CompactDecimal a(a_significand, a_exponent);
+    CompactDecimal b(b_significand, b_exponent);
+    return a.compare_to(b);
+}
+
+static
+Sign compare_with_exponent(uint64_t a, uint64_t b, uint32_t exponent) {
+    if (a == UINT64_C(0) || b == UINT64_C(0)) {
+        return compare_value(a, b);
+    }
+    if (exponent < s_compact_exponents.size()) {
+        // (a <=> b*10^{exponent}) == (a / 10^{exponent} <=> b)
+        uint64_t s = s_compact_exponents[exponent];
+        uint64_t div = a / s;
+        uint64_t mod = a % s;
+        RETURN_IF_DIFFERENT(compare_value(div, b));
+        return compare_value(mod, UINT64_C(0));
+    }
+    /*
+     * always a <= b * s,
+     * where a < 2^{64}, b >= 1, s >= 10^{20} > 2^{64}
+     */
+    assert(b != 0);
+    return Sign::less_than;
+}
+
+static
+Sign compare_with_exponent(uint64_t a, const MpInt& b, uint32_t exponent) {
+    if (a == UINT64_C(0)) {
+        if (b == UINT64_C(0)) {
+            return Sign::equal_to;
+        } else {
+            return Sign::less_than;
+        }
+    } else if (b == UINT64_C(0)) {
+        return Sign::greater_than;
+    }
+    if (exponent < s_compact_exponents.size()) {
+        // (a <=> b*10^{exponent}) == (a / 10^{exponent} <=> b)
+        uint64_t s = s_compact_exponents[exponent];
+        uint64_t div = a / s;
+        uint64_t mod = a % s;
+        RETURN_IF_DIFFERENT(negate(b.compare_to(div)));
+        return compare_value(mod, UINT64_C(0));
+    }
+    /*
+     * always a <= b * s,
+     * where a < 2^{64}, b >= 1, s >= 10^{20} > 2^{64}
+     */
+    assert(b != UINT64_C(0));
+    return Sign::less_than;
+}
+
+static
+Sign compare_with_exponent(const MpInt& a, uint64_t b, uint32_t exponent) {
+    if (a == UINT64_C(0)) {
+        return compare_value(UINT64_C(0), b);
+    } else if (b == UINT64_C(0)) {
+        return Sign::greater_than;
+    }
+    return compare_with_exponent(a, MpInt(b), exponent);
+}
+
+inline
+static std::tuple<uint32_t, uint32_t> predicate_product_bits(const MpInt &significand, uint32_t exponent) {
+    if (significand == UINT64_C(0)) {
+        return std::make_tuple(UINT32_C(0), UINT32_C(0));
+    }
+    uint32_t a_bits = significand.bits();
+
+    /*
+     * log_{2}(10) = 3.32...
+     * 2^{3.3} < 10 < 2^{3.33..}
+     * 2^{3.3n} < 10^{n} < 2^{10n/3}
+     */
+    uint32_t b_bits_min = static_cast<uint32_t>(std::floor(exponent * 3.3));
+    uint32_t b_bits_max = (exponent * 10 + 2) / 3;
+
+    /*
+     * where X is a m-bits unsigned integer, where m>0, and
+     * Y is a n-bits unsigned integer, where n>0.
+     *
+     * 2^{m-1} <= X < 2^{m},
+     * 2^{n-1} <= Y < 2^{n},
+     * 2^{n+m-2} <= X*Y < 2^{m+n}.
+     *
+     * X*Y must always have [n+m-1, n+m] bits.
+     */
+    return std::make_tuple<uint32_t, uint32_t>(a_bits + b_bits_min - 1, a_bits + b_bits_max);
+}
+
+/**
+ * \brief Compares a <=> b*10^{exponent}
+ */
+static
+Sign compare_with_exponent(const MpInt &a, const MpInt &b, uint32_t exponent) {
+    if (exponent == UINT32_C(0)) {
+        return a.compare_to(b);
+    }
+    if (a == UINT64_C(0)) {
+        if (b == UINT64_C(0)) {
+            return Sign::equal_to;
+        } else {
+            return Sign::less_than;
+        }
+    } else if (b == UINT64_C(0)) {
+        return Sign::greater_than;
+    }
+    /*
+     * where
+     * X is a m-bits unsigned integer, where m>=0, and
+     * Y is a n-bits unsigned integer, where n>=0.
+     *
+     * m < n --> X < Y
+     * m > n --> X > Y
+     */
+    uint32_t a_bits = a.bits();
+    auto b_bits_range = predicate_product_bits(b, exponent);
+    if (a_bits < std::get<0>(b_bits_range)) {
+        return Sign::less_than;
+    }
+    if (a_bits > std::get<1>(b_bits_range)) {
+        return Sign::greater_than;
+    }
+
+    if (exponent <= 9) {
+        // 10^9 < 2^{30}
+        assert(s_compact_exponents[exponent] <= UINT64_C(0xffffffff));
+        return a.compare_to(b * static_cast<uint32_t>(s_compact_exponents[exponent]));
+    }
+    MpInt b_product = b * MpInt::power_of_10(exponent);
+    return a.compare_to(b_product);
+}

--- a/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/io/SerDeNativeTest.java
+++ b/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/io/SerDeNativeTest.java
@@ -23,10 +23,15 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.hamcrest.Matcher;
 import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -35,6 +40,7 @@ import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.asakusafw.dag.runtime.testing.ClosablePointer;
 import com.asakusafw.runtime.io.util.DataBuffer;
 import com.asakusafw.runtime.value.BooleanOption;
 import com.asakusafw.runtime.value.ByteOption;
@@ -379,6 +385,437 @@ public class SerDeNativeTest {
     }
 
     /**
+     * mpint - simple case.
+     */
+    @Test
+    public void mpint_simple() {
+        Memory buf = bytes(100);
+        BigInteger r = toBigInt(() -> MAPPER.jna_mpint(buf, buf.size()));
+        assertThat(r, is(toBigInt("100")));
+    }
+
+    /**
+     * mpint - multiple words.
+     */
+    @Test
+    public void mpint_multiple_words() {
+        Memory buf = bytes(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+        byte[] r = toBytes(() -> MAPPER.jna_mpint(buf, size(buf)));
+        assertThat(r, is(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 }));
+    }
+
+    /**
+     * mpint - leading zeros.
+     */
+    @Test
+    public void mpint_leading_zeros() {
+        Memory buf = bytes(0, 0, 0, 0, 0, 1, 2, 3);
+        byte[] r = toBytes(() -> MAPPER.jna_mpint(buf, size(buf)));
+        assertThat(r, is(new byte[] { 1, 2, 3 }));
+    }
+
+    /**
+     * mpint - just zero.
+     */
+    @Test
+    public void mpint_zero() {
+        byte[] r = toBytes(() -> MAPPER.jna_mpint(Pointer.NULL, 0));
+        assertThat(r, is(new byte[0]));
+    }
+
+    /**
+     * mpint - zero w/ leading zeros.
+     */
+    @Test
+    public void mpint_zero_leading_zeros() {
+        Memory buf = bytes(0);
+        byte[] r = toBytes(() -> MAPPER.jna_mpint(buf, size(buf)));
+        assertThat(r, is(new byte[0]));
+    }
+
+    /**
+     * mpint - multiply.
+     */
+    @Test
+    public void mpint_mult() {
+        BigInteger a = toBigInt("12398530985723743985");
+        int b = 2;
+        BigInteger c = mpintMult(a, b);
+        assertThat(c, is(a.multiply(BigInteger.valueOf(b))));
+    }
+
+    /**
+     * mpint - multiply.
+     */
+    @Test
+    public void mpint_mult_mp() {
+        BigInteger a = toBigInt("1000000");
+        BigInteger b = toBigInt("1000000");
+        BigInteger c = mpintMult(a, b);
+        assertThat(c, is(a.multiply(b)));
+    }
+
+    /**
+     * mpint - multiply.
+     */
+    @Test
+    public void mpint_mult_mp_huge() {
+        BigInteger a = toBigInt("378238523420943283472343782");
+        BigInteger b = toBigInt("124766129372357435248");
+        BigInteger c = mpintMult(a, b);
+        assertThat(c, is(a.multiply(b)));
+    }
+
+    /**
+     * mpint - compare.
+     */
+    @Test
+    public void mpint_compare_w0() {
+        assertThat(mpintCompare("0", 0), equalTo(0));
+        assertThat(mpintCompare("0", 1), lessThan(0));
+        assertThat(mpintCompare("0", 0x12_3456_789aL), lessThan(0));
+    }
+
+    /**
+     * mpint - compare.
+     */
+    @Test
+    public void mpint_compare_w1() {
+        assertThat(mpintCompare("100", 0), greaterThan(0));
+        assertThat(mpintCompare("100", 1), greaterThan(0));
+        assertThat(mpintCompare("100", 99), greaterThan(0));
+        assertThat(mpintCompare("100", 100), equalTo(0));
+        assertThat(mpintCompare("100", 101), lessThan(0));
+        assertThat(mpintCompare("100", 0xffff_ffffL), lessThan(0));
+        assertThat(mpintCompare("100", 0x1_0000_0000L), lessThan(0));
+        assertThat(mpintCompare("100", 0x12_3456_789aL), lessThan(0));
+    }
+
+    /**
+     * mpint - compare.
+     */
+    @Test
+    public void mpint_compare_w2() {
+        assertThat(mpintCompare("0x1234_5678_9abc_def0", 0), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0", 100), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0", 0xffff_ffffL), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0", 0x1_0000_0000L), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0", 0x1234_5678_9abc_def0L), equalTo(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0", 0x1234_5678_9abc_def1L), lessThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0", 0x7fff_ffff_ffff_ffffL), lessThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0", 0xffff_ffff_ffff_ffffL), lessThan(0));
+    }
+
+    /**
+     * mpint - compare.
+     */
+    @Test
+    public void mpint_compare_w3() {
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", 0), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", 100), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", 0xffff_ffffL), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", 0x1_0000_0000L), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", 0x7fff_ffff_ffff_ffffL), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", 0xffff_ffff_ffff_ffffL), greaterThan(0));
+    }
+
+    /**
+     * mpint - compare.
+     */
+    @Test
+    public void mpint_compare_mp_w0() {
+        assertThat(mpintCompare("0", "0"), equalTo(0));
+        assertThat(mpintCompare("0", "1"), lessThan(0));
+        assertThat(mpintCompare("0", "0x1234_5678_9abc"), lessThan(0));
+        assertThat(mpintCompare("0", "0x1234_5678_9abc_def0_1234"), lessThan(0));
+    }
+
+    /**
+     * mpint - compare.
+     */
+    @Test
+    public void mpint_compare_mp_w1() {
+        assertThat(mpintCompare("0x1234", "0"), greaterThan(0));
+        assertThat(mpintCompare("0x1234", "0x1233"), greaterThan(0));
+        assertThat(mpintCompare("0x1234", "0x1234"), equalTo(0));
+        assertThat(mpintCompare("0x1234", "0x1235"), lessThan(0));
+        assertThat(mpintCompare("0x1234", "0x1234_5678_9abc"), lessThan(0));
+        assertThat(mpintCompare("0x1234", "0x1234_5678_9abc_def0_1234"), lessThan(0));
+    }
+
+    /**
+     * mpint - compare.
+     */
+    @Test
+    public void mpint_compare_mp_w2() {
+        assertThat(mpintCompare("0x1234_5678_9abc", "0"), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc", "0x1234"), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc", "0x1234_5678_9abb"), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc", "0x1234_5678_9abc"), equalTo(0));
+        assertThat(mpintCompare("0x1234_5678_9abc", "0x1234_5678_9abd"), lessThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc", "0x1234_5678_9abc_def0_1234"), lessThan(0));
+    }
+
+    /**
+     * mpint - compare.
+     */
+    @Test
+    public void mpint_compare_mp_w3() {
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", "0"), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", "0x1234"), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", "0x1234_5678_9abc"), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", "0x1234_5678_9abc_def0_1233"), greaterThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", "0x1234_5678_9abc_def0_1234"), equalTo(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", "0x1234_5678_9abc_def0_1235"), lessThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", "0x1234_5678_9abc_def0_1234_0"), lessThan(0));
+        assertThat(mpintCompare("0x1234_5678_9abc_def0_1234", "0x1234_5678_9abc_def0_1234_5678_9abc"), lessThan(0));
+    }
+
+    /**
+     * mpint - 10^n.
+     */
+    @Test
+    public void mpint_pow_of_10() {
+        for (int i = 0; i < 100; i++) {
+            int exp = i;
+            BigInteger r = toBigInt(() -> MAPPER.jna_mpint_pow_of_10(exp));
+            assertThat(r, is(BigInteger.TEN.pow(exp)));
+        }
+    }
+
+    private BigInteger mpintMult(BigInteger a, int b) {
+        Memory p = toMpInt(a);
+        try (ClosablePointer c = new ClosablePointer(MAPPER.jna_mpint_mult(p, size(p), b))) {
+            return toBigInt(c);
+        }
+    }
+
+    private BigInteger mpintMult(BigInteger a, BigInteger b) {
+        Memory pA = toMpInt(a);
+        Memory pB = toMpInt(b);
+        try (ClosablePointer c = new ClosablePointer(MAPPER.jna_mpint_mult_mp(pA, size(pA), pB, size(pB)))) {
+            return toBigInt(c);
+        }
+    }
+
+    private int mpintCompare(String a, long b) {
+        Memory m = toMpInt(toBigInt(a));
+        return MAPPER.jna_mpint_cmp(m, size(m), b);
+    }
+
+    private long size(Pointer ptr) {
+        if (ptr instanceof Memory) {
+            return ((Memory) ptr).size();
+        } else if (ptr == Pointer.NULL || ptr == null) {
+            return 0;
+        } else {
+            throw new AssertionError();
+        }
+    }
+
+    private int mpintCompare(String a, String b) {
+        Memory p0 = toMpInt(toBigInt(a));
+        Memory p1 = toMpInt(toBigInt(b));
+        return MAPPER.jna_mpint_cmp_mp(p0, size(p0), p1, size(p1));
+    }
+
+    private BigInteger toBigInt(String s) {
+        String v = s.replaceAll("_", "");
+        boolean hex = false;
+        if (v.startsWith("0x")) {
+            hex = true;
+            v = v.substring(2);
+        }
+        return new BigInteger(v, hex ? 16 : 10);
+    }
+
+    private Memory bytes(int... bytes) {
+        Memory memory = new Memory(bytes.length);
+        for (int i = 0; i < bytes.length; i++) {
+            memory.setByte(i, (byte) bytes[i]);
+        }
+        return memory;
+    }
+
+    private Memory toMpInt(BigInteger value) {
+        if (value.equals(BigInteger.ZERO)) {
+            return null;
+        }
+        assertThat(value.signum(), is(1));
+        byte[] bytes = value.toByteArray();
+        Memory memory = new Memory(bytes.length);
+        for (int i = 0; i < bytes.length; i++) {
+            memory.setByte(i, bytes[i]);
+        }
+        return memory;
+    }
+
+    private BigInteger toBigInt(Supplier<Pointer> s) {
+        try (ClosablePointer c = new ClosablePointer(s.get())) {
+            return toBigInt(c);
+        }
+    }
+
+    private byte[] toBytes(Supplier<Pointer> s) {
+        try (ClosablePointer c = new ClosablePointer(s.get())) {
+            return toBytes(c);
+        }
+    }
+
+    private byte[] toBytes(Pointer ptr) {
+        int size = ptr.getByte(0) & 0xff;
+        return ptr.getByteArray(Byte.BYTES, size);
+    }
+
+    private BigInteger toBigInt(Pointer ptr) {
+        byte[] mpint = toBytes(ptr);
+        return new BigInteger(1, mpint);
+    }
+
+    /**
+     * Test for {@code compare_decimal} w/ {compact, compact}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_decimal_compact_compact() throws Exception {
+        assertCompare("0", 0, "0", 0, 0);
+        assertCompare("0", 0, "0", 10, 0);
+
+        assertCompare("0", 0, "1", 0, -1);
+        assertCompare("0", 0, "1", 10, -1);
+
+        assertCompare("1", 10, "1", 10, 0);
+        assertCompare("1", 10, "2", 10, -1);
+        assertCompare("2", 10, "1", 10, +1);
+
+        assertCompare("1", 10, "10", 9, 0);
+        assertCompare("1", 10, "11", 9, -1);
+        assertCompare("1", 10, "_9", 9, +1);
+
+        assertCompare("1", 10, "10000000000", 0, 0);
+        assertCompare("1", 10, "10000000001", 0, -1);
+        assertCompare("1", 10, "_9999999999", 0, +1);
+
+        assertCompare("1", 18, "1000000000000000000", 0, 0);
+        assertCompare("1", 18, "1000000000100000000", 0, -1);
+        assertCompare("1", 18, "_999999999900000000", 0, +1);
+
+        assertCompare("1", 20, "9223372036854775807", 0, +1);
+        assertCompare("1", 20, "9223372036854775807", 2, -1);
+    }
+
+    /**
+     * Test for {@code compare_decimal} w/ (compact, mp).
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_decimal_compact_mp() throws Exception {
+        int ePad = 20;
+        String sPad = Stream.generate(() -> "0").limit(ePad).collect(Collectors.joining());
+
+        assertCompare("0", 0 + ePad, "0" + sPad, 0, 0);
+        assertCompare("0", 0 + ePad, "0" + sPad, 10, 0);
+
+        assertCompare("1", 10 + ePad, "1" + sPad, 10, 0);
+        assertCompare("1", 10 + ePad, "2" + sPad, 10, -1);
+        assertCompare("2", 10 + ePad, "1" + sPad, 10, +1);
+
+        assertCompare("1", 10 + ePad, "10" + sPad, 9, 0);
+        assertCompare("1", 10 + ePad, "11" + sPad, 9, -1);
+        assertCompare("1", 10 + ePad, "_9" + sPad, 9, +1);
+
+        assertCompare("1", 10 + ePad, "10000000000" + sPad, 0, 0);
+        assertCompare("1", 10 + ePad, "10000000001" + sPad, 0, -1);
+        assertCompare("1", 10 + ePad, "_9999999999" + sPad, 0, +1);
+
+        assertCompare("1", 18 + ePad, "1000000000000000000" + sPad, 0, 0);
+        assertCompare("1", 18 + ePad, "1000000000100000000" + sPad, 0, -1);
+        assertCompare("1", 18 + ePad, "_999999999900000000" + sPad, 0, +1);
+
+        assertCompare("1", 20 + ePad, "9223372036854775807" + sPad, 0, +1);
+        assertCompare("1", 20 + ePad, "9223372036854775807" + sPad, 2, -1);
+    }
+
+    /**
+     * Test for {@code compare_decimal} w/ (compact, mp).
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_decimal_mp_compact() throws Exception {
+        int ePad = 20;
+        String sPad = Stream.generate(() -> "0").limit(ePad).collect(Collectors.joining());
+
+        assertCompare("1" + sPad, 10, "1", 10 + ePad, 0);
+        assertCompare("1" + sPad, 10, "2", 10 + ePad, -1);
+        assertCompare("2" + sPad, 10, "1", 10 + ePad, +1);
+
+        assertCompare("1" + sPad, 10, "10", 9 + ePad, 0);
+        assertCompare("1" + sPad, 10, "11", 9 + ePad, -1);
+        assertCompare("1" + sPad, 10, "_9", 9 + ePad, +1);
+
+        assertCompare("1" + sPad, 10, "10000000000", 0 + ePad, 0);
+        assertCompare("1" + sPad, 10, "10000000001", 0 + ePad, -1);
+        assertCompare("1" + sPad, 10, "_9999999999", 0 + ePad, +1);
+
+        assertCompare("1" + sPad, 18, "1000000000000000000", 0 + ePad, 0);
+        assertCompare("1" + sPad, 18, "1000000000100000000", 0 + ePad, -1);
+        assertCompare("1" + sPad, 18, "_999999999900000000", 0 + ePad, +1);
+
+        assertCompare("1" + sPad, 20, "9223372036854775807", 0 + ePad, +1);
+        assertCompare("1" + sPad, 20, "9223372036854775807", 2 + ePad, -1);
+    }
+
+    /**
+     * Test for {@code compare_decimal} w/ {mp, mp}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_decimal_mp_mp() throws Exception {
+        int ePad = 20;
+        String sPad = Stream.generate(() -> "0").limit(ePad).collect(Collectors.joining());
+
+        assertCompare("0", 0, "1" + sPad, -ePad, -1);
+
+        assertCompare("1" + sPad, 10, "1" + sPad, 10, 0);
+        assertCompare("1" + sPad, 10, "2" + sPad, 10, -1);
+        assertCompare("2" + sPad, 10, "1" + sPad, 10, +1);
+
+        assertCompare("1" + sPad, 10, "10" + sPad, 9, 0);
+        assertCompare("1" + sPad, 10, "11" + sPad, 9, -1);
+        assertCompare("1" + sPad, 10, "_9" + sPad, 9, +1);
+
+        assertCompare("1" + sPad, 10, "10000000000" + sPad, 0, 0);
+        assertCompare("1" + sPad, 10, "10000000001" + sPad, 0, -1);
+        assertCompare("1" + sPad, 10, "_9999999999" + sPad, 0, +1);
+
+        assertCompare("1" + sPad, 18, "1000000000000000000" + sPad, 0, 0);
+        assertCompare("1" + sPad, 18, "1000000000100000000" + sPad, 0, -1);
+        assertCompare("1" + sPad, 18, "_999999999900000000" + sPad, 0, +1);
+
+        assertCompare("1" + sPad, 20, "9223372036854775807" + sPad, 0, +1);
+        assertCompare("1" + sPad, 20, "9223372036854775807" + sPad, 2, -1);
+    }
+
+    private void assertCompare(String s0, int e0, String s1, int e1, int sign) {
+        DecimalOption d0 = newDecimal(s0, e0);
+        DecimalOption d1 = newDecimal(s1, e1);
+        assertCompare0(d0, d1, sign);
+        assertCompare0(d1, d0, -sign);
+    }
+
+    private void assertCompare0(DecimalOption a, DecimalOption b, int sign) {
+        Comparator<DecimalOption> cmp = comparator(MAPPER::jna_compare_decimal);
+        Matcher<Integer> result = sign == 0 ? equalTo(0) : sign < 0 ? lessThan(0) : greaterThan(0);
+        assertThat(cmp.compare(a, b), result);
+    }
+
+    // significand * 10^{exponent}
+    private DecimalOption newDecimal(String significand, int exponent) {
+        BigInteger sig = toBigInt(significand);
+        return new DecimalOption(new BigDecimal(sig, -exponent));
+    }
+
+    /**
      * native mapper.
      */
     @SuppressWarnings("javadoc")
@@ -397,5 +834,15 @@ public class SerDeNativeTest {
         int jna_compare_date_time(Pointer a, Pointer b);
         int jna_compare_string(Pointer a, Pointer b);
         int jna_compare_decimal(Pointer a, Pointer b);
+
+        Pointer jna_mpint(Pointer buf, long length);
+
+        Pointer jna_mpint_mult(Pointer buf, long length, int multiplier);
+        Pointer jna_mpint_mult_mp(Pointer b0, long l0, Pointer b1, long l1);
+
+        int jna_mpint_cmp(Pointer buf, long length, long other);
+        int jna_mpint_cmp_mp(Pointer b0, long l0, Pointer b1, long l1);
+
+        Pointer jna_mpint_pow_of_10(int exponent);
     }
 }

--- a/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/testing/ClosablePointer.java
+++ b/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/testing/ClosablePointer.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.testing;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+
+/**
+ * Releases {@link Pointer}.
+ */
+public class ClosablePointer extends Pointer implements AutoCloseable {
+
+    /**
+     * Creates a new instance.
+     * @param pointer the target pointer
+     */
+    public ClosablePointer(Pointer pointer) {
+        super(Pointer.nativeValue(pointer));
+    }
+
+    @Override
+    public void close() {
+        Native.free(Pointer.nativeValue(this));
+    }
+}

--- a/runtime/runtime/src/test/native/serde/CMakeLists.txt
+++ b/runtime/runtime/src/test/native/serde/CMakeLists.txt
@@ -3,8 +3,9 @@ cmake_minimum_required(VERSION 2.8)
 project(test-serde)
 
 file(GLOB NATIVE "*.cpp")
+file(GLOB CORE "../../../main/resources/com/asakusafw/dag/runtime/io/native/src/*.cpp")
 
 include_directories("../../../main/resources/com/asakusafw/dag/runtime/io/native/include")
 
-add_library(test-serde SHARED ${NATIVE})
+add_library(test-serde SHARED ${NATIVE} ${CORE})
 set_target_properties(test-serde PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")


### PR DESCRIPTION
## Summary

This commit enables to handle decimals which have large significand (greater than 63-bits, approx. 18-digits), in native value comparators.
## Background, Problem or Goal of the patch

[Asakusa on M3BP](https://github.com/asakusafw/asakusafw-m3bp) `<= 0.1.1` cannot handle decimals with large significand in sorting group members, and only can handle decimals with `< 2^63` significand.
## Design of the fix, or a new feature

This commit includes the following C++ classes:
- `CompactDecimal`
  - unsigned decimal with `< 2^64` significand 
- `MpInt`
  - multi-precision integer
- `MpDecimal`
  - unsigned decimal with multi-precision significand

The both `{Compact,Mp}Decimal` represents `significand * 10^{exponent}`. The former uses `unsigned long long (uint64_t)` for its significand, and the latter uses `MpInt`. In many cases, decimals only have `<= 18` digits and `CompactDecimal` will be used.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

N/A.
