### PR TITLE
Apply OperatorRewriters until they become stable.

### DIFF
--- a/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/DagPlanning.java
+++ b/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/DagPlanning.java
@@ -83,10 +83,14 @@ import com.asakusafw.utils.graph.Graph;
  *      for {@link com.asakusafw.lang.compiler.planning.SubPlan.Output SubPlan.Output}
  * </li>
  * </ul>
+ * @since 0.1.0
+ * @version 0.1.2
  */
 public final class DagPlanning {
 
     static final Logger LOG = LoggerFactory.getLogger(DagPlanning.class);
+
+    private static final int OPTIMIZATION_STEP_LIMIT = 1_000;
 
     /**
      * The compiler property key prefix of planning options.
@@ -190,15 +194,33 @@ public final class DagPlanning {
      */
     static void prepareOperatorGraph(PlanningContext context, OperatorGraph graph) {
         Planning.normalize(graph);
-        Planning.removeDeadFlow(graph);
-        OperatorRewriters.apply(
-                context.getOptimizerContext(),
-                context.getEstimator(),
-                context.getRewriter(),
-                graph);
-        graph.rebuild();
+        optimize(context, graph);
         insertPlanMarkers(context, graph);
         Planning.simplifyTerminators(graph);
+    }
+
+    private static void optimize(PlanningContext context, OperatorGraph graph) {
+        int step = 0;
+        boolean changed;
+        do {
+            step++;
+            LOG.debug("optimize step#{}", step);
+            Planning.removeDeadFlow(graph);
+            if (step > OPTIMIZATION_STEP_LIMIT) {
+                LOG.warn(MessageFormat.format(
+                        "the number of optimization steps exceeded limit: {0}",
+                        OPTIMIZATION_STEP_LIMIT));
+                break;
+            }
+            OperatorGraph.Snapshot before = graph.getSnapshot();
+            OperatorRewriters.apply(
+                    context.getOptimizerContext(),
+                    context.getEstimator(),
+                    context.getRewriter(),
+                    graph);
+            OperatorGraph.Snapshot after = graph.getSnapshot();
+            changed = before.equals(after) == false;
+        } while (changed);
     }
 
     static void insertPlanMarkers(PlanningContext context, OperatorGraph graph) {


### PR DESCRIPTION
## Summary

This commit enables to apply a pair of operator rewriters and dead-flow elision optimization until operator graph becomes stable.
## Background, Problem or Goal of the patch

Some optimizations (e.g. asakusafw/asakusafw-compiler#54) may remove operators from the operator graph. It can introduce new dead-flows, and some optimization requires such dead-flows are already removed from the operator graph. This commit will fix this problem by applying optimizations recursively.
## Design of the fix, or a new feature

We first take snapshots before/after applying optimizations, and compare each other to detect whether the optimizations become convergent or not. 
## Related Issue, Pull Request or Code
- asakusafw/asakusafw-compiler#54
- asakusafw/asakusafw-spark#173
## Wanted reviewer

@akirakw 
