### PR TITLE
Enable to put module versions into compiler's build log.

### DIFF
--- a/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/Info.java
+++ b/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/Info.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.compiler.builtin;
+
+import com.asakusafw.lang.compiler.api.ExtensionInfo;
+
+/**
+ * Information of this extension module.
+ * @since 0.1.2
+ */
+public class Info implements ExtensionInfo {
+
+    @Override
+    public String getName() {
+        return "dag.analyzer";
+    }
+}

--- a/compiler/builtin/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
+++ b/compiler/builtin/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
@@ -1,0 +1,1 @@
+com.asakusafw.dag.compiler.builtin.Info

--- a/compiler/directio/src/main/java/com/asakusafw/dag/compiler/directio/Info.java
+++ b/compiler/directio/src/main/java/com/asakusafw/dag/compiler/directio/Info.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.compiler.directio;
+
+import com.asakusafw.lang.compiler.api.ExtensionInfo;
+
+/**
+ * Information of this extension module.
+ * @since 0.1.2
+ */
+public class Info implements ExtensionInfo {
+
+    @Override
+    public String getName() {
+        return "dag.directio";
+    }
+}

--- a/compiler/directio/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
+++ b/compiler/directio/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
@@ -1,0 +1,1 @@
+com.asakusafw.dag.compiler.directio.Info

--- a/compiler/internalio/src/main/java/com/asakusafw/dag/compiler/internalio/Info.java
+++ b/compiler/internalio/src/main/java/com/asakusafw/dag/compiler/internalio/Info.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.compiler.internalio;
+
+import com.asakusafw.lang.compiler.api.ExtensionInfo;
+
+/**
+ * Information of this extension module.
+ * @since 0.1.2
+ */
+public class Info implements ExtensionInfo {
+
+    @Override
+    public String getName() {
+        return "dag.internalio";
+    }
+}

--- a/compiler/internalio/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
+++ b/compiler/internalio/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
@@ -1,0 +1,1 @@
+com.asakusafw.dag.compiler.internalio.Info

--- a/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/Info.java
+++ b/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/Info.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.compiler.planner;
+
+import com.asakusafw.lang.compiler.api.ExtensionInfo;
+
+/**
+ * Information of this extension module.
+ * @since 0.1.2
+ */
+public class Info implements ExtensionInfo {
+
+    @Override
+    public String getName() {
+        return "dag.planner";
+    }
+}

--- a/compiler/plan/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
+++ b/compiler/plan/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
@@ -1,0 +1,1 @@
+com.asakusafw.dag.compiler.planner.Info


### PR DESCRIPTION
## Summary

This commit enables to put `asakusafw-dag` module versions into compiler's build log.
## Background, Problem or Goal of the patch

The compiler's build log only includes information about terminal extensions, so that the assistant modules in `asakusafw-dag` were not appeared in it.
## Design of the fix, or a new feature

see asakusafw/asakusafw-compiler#59
## Related Issue, Pull Request or Code

asakusafw/asakusafw-compiler#59
## Wanted reviewer

@akirakw
