### PR TITLE
Fix bug on comparing decimals.

### DIFF
--- a/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/include/mpdecimal.hpp
+++ b/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/include/mpdecimal.hpp
@@ -65,7 +65,7 @@ class MpInt {
 public:
     /*
      * \brief The default constructor.
-     * The created object will just represents zero.
+     * The created object will just represent zero.
      */
     MpInt() = default;
 
@@ -168,8 +168,8 @@ public:
     inline
     bool operator==(uint64_t other) const {
         if (m_members.empty()) {
-            return other == 0ULL;
-        } else if (other == 0ULL) {
+            return other == UINT64_C(0ULL);
+        } else if (other == UINT64_C(0ULL)) {
             return false;
         } else if (m_members.size() == 1) {
             return m_members.front() == other;
@@ -246,13 +246,13 @@ private:
 
 /*
  * \brief A simple compact unsigned decimal.
- * This only can represent [0, 2^{64}).
+ * This only can have a significand in the range of [0, 2^{64}).
  */
 class CompactDecimal {
 public:
     /*
      * \brief The default constructor.
-     * The created object will just represents zero.
+     * The created object will just represent zero.
      */
     CompactDecimal() = default;
 
@@ -333,7 +333,7 @@ class MpDecimal {
 public:
     /*
      * \brief The default constructor.
-     * The created object will just represents zero.
+     * The created object will just represent zero.
      */
     MpDecimal() = default;
 

--- a/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/include/mpdecimal.hpp
+++ b/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/include/mpdecimal.hpp
@@ -168,8 +168,8 @@ public:
     inline
     bool operator==(uint64_t other) const {
         if (m_members.empty()) {
-            return other == UINT64_C(0ULL);
-        } else if (other == UINT64_C(0ULL)) {
+            return other == UINT64_C(0);
+        } else if (other == UINT64_C(0)) {
             return false;
         } else if (m_members.size() == 1) {
             return m_members.front() == other;

--- a/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/src/mpdecimal.cpp
+++ b/runtime/runtime/src/main/resources/com/asakusafw/dag/runtime/io/native/src/mpdecimal.cpp
@@ -257,19 +257,6 @@ static Sign compare_value(T a, T b) {
     return a == b ? Sign::equal_to : a < b ? Sign::less_than : Sign::greater_than;
 }
 
-inline
-static Sign compare_memory(
-        const uint8_t *a_buf, std::size_t a_length,
-        const uint8_t *b_buf, std::size_t b_length) {
-    std::size_t length = std::min(a_length, b_length);
-    if (length != 0) {
-        int diff = memcmp(a_buf, b_buf, length);
-        RETURN_IF_DIFFERENT(compare_value(diff, 0));
-    }
-    RETURN_IF_DIFFERENT(compare_value(a_length, b_length));
-    return Sign::equal_to;
-}
-
 Sign MpInt::compare_to(uint64_t other) const {
     std::size_t words = m_members.size();
     if (words == 0) {
@@ -420,9 +407,6 @@ Sign MpDecimal::compare_to(const MpDecimal& other) const {
 Sign asakusafw::math::compare_decimal(
         const uint8_t *a_buf, std::size_t a_length, int32_t a_exponent,
         const uint8_t *b_buf, std::size_t b_length, int32_t b_exponent) {
-    if (a_exponent == b_exponent) {
-        return compare_memory(a_buf, a_length, b_buf, b_length);
-    }
     MpDecimal a(a_buf, a_length, a_exponent);
     MpDecimal b(b_buf, b_length, b_exponent);
     return a.compare_to(b);

--- a/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/io/SerDeNativeTest.java
+++ b/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/io/SerDeNativeTest.java
@@ -794,6 +794,8 @@ public class SerDeNativeTest {
 
         assertCompare("1" + sPad, 20, "9223372036854775807" + sPad, 0, +1);
         assertCompare("1" + sPad, 20, "9223372036854775807" + sPad, 2, -1);
+
+        assertCompare("0x1234_12345678_12345678", 0, "0x__34_12345678_12345678", 0, +1);
     }
 
     private void assertCompare(String s0, int e0, String s1, int e1, int sign) {


### PR DESCRIPTION
## Summary

This commit fixes bug on the native decimal comparator function.
## Background, Problem or Goal of the patch

In #25, the decimal comparator returns wrong result in the following situation:
- both significands are >= 2^63 (using `MpDecimal`),
- both exponents are equivalent,
- the former significand has different byte length from the latter one, and
- the smaller one's significand bytes is greater than another in dictionary order (using `memcmp`).

(e.g.) `0x1234_12345678_12345678 <=> 0x34_12345678_12345678`
## Design of the fix, or a new feature

This commit just removes short circuit about the above situation (near `compare_memory`).
## Related Issue, Pull Request or Code
- #25
- #28
## Wanted reviewer

N/A.
