### PR TITLE
Fix race condition in BasicConnectionPool.

### DIFF
--- a/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/basic/BasicConnectionPool.java
+++ b/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/basic/BasicConnectionPool.java
@@ -168,12 +168,14 @@ public class BasicConnectionPool implements ConnectionPool {
         }
         try (Closer closer = new Closer()) {
             closer.add(JdbcUtil.wrap(connection::close));
-            if (connection.isClosed() == false && connection.getAutoCommit() == false) {
-                connection.rollback();
-            }
-            if (poolClosed == false) {
-                closer.keep();
+            if (connection.isClosed() == false) {
+                if (connection.getAutoCommit() == false) {
+                    connection.rollback();
+                }
                 cached.add(connection);
+                if (poolClosed == false) {
+                    closer.keep();
+                }
             }
         } catch (SQLException e) {
             throw JdbcUtil.wrap(e);


### PR DESCRIPTION
## Summary

This PR fixes leakage of JDBC connections in WindGate JDBC direct mode.
## Background, Problem or Goal of the patch

`BasicConnectionPool` has race condition between `release()` and `close()`.

| Time | release() | close() |
| :-: | :-: | :-: |
| t1 | `if (!poolClosed) ...` |  |
| t2 |  | `poolClosed=true` |
| t3 |  | `cached.*close()` |
| t4 | `cached.add(connection)` |  |

Finally, `connection` will leak at `t4`.
## Design of the fix, or a new feature

This fix just reverses checking `poolClosed` flag with `cached.add(connection)` in `release()`. Their cached connections will be closed if the connection pool was already closed.
## Related Issue, Pull Request or Code
- #41
## Wanted reviewer

@shino
