### PR TITLE
Add a set of pure Java value comparator facilities.

### DIFF
--- a/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/DataComparatorGenerator.java
+++ b/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/DataComparatorGenerator.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.compiler.codegen;
+
+import static com.asakusafw.dag.compiler.codegen.AsmUtil.*;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import com.asakusafw.dag.api.common.DataComparator;
+import com.asakusafw.dag.compiler.codegen.AsmUtil.LocalVarRef;
+import com.asakusafw.dag.compiler.model.ClassData;
+import com.asakusafw.dag.runtime.io.ValueOptionSerDe;
+import com.asakusafw.dag.utils.common.Arguments;
+import com.asakusafw.dag.utils.common.Invariants;
+import com.asakusafw.lang.compiler.api.reference.DataModelReference;
+import com.asakusafw.lang.compiler.api.reference.PropertyReference;
+import com.asakusafw.lang.compiler.model.description.ClassDescription;
+import com.asakusafw.lang.compiler.model.description.Descriptions;
+import com.asakusafw.lang.compiler.model.description.TypeDescription;
+import com.asakusafw.lang.compiler.model.graph.Group;
+import com.asakusafw.runtime.value.BooleanOption;
+import com.asakusafw.runtime.value.ByteOption;
+import com.asakusafw.runtime.value.DateOption;
+import com.asakusafw.runtime.value.DateTimeOption;
+import com.asakusafw.runtime.value.DecimalOption;
+import com.asakusafw.runtime.value.DoubleOption;
+import com.asakusafw.runtime.value.FloatOption;
+import com.asakusafw.runtime.value.IntOption;
+import com.asakusafw.runtime.value.LongOption;
+import com.asakusafw.runtime.value.ShortOption;
+import com.asakusafw.runtime.value.StringOption;
+
+/**
+ * Generates {@link DataComparator}.
+ * @since 0.2.0
+ */
+public final class DataComparatorGenerator {
+
+    private static final String CATEGORY = "compare"; //$NON-NLS-1$
+
+    private static final String SUFFIX = "Comparator"; //$NON-NLS-1$
+
+    private static final Type TYPE_DATA_INPUT = typeOf(DataInput.class);
+
+    private static final String DESC_COMPARE = Type.getMethodDescriptor(
+            typeOf(int.class), TYPE_DATA_INPUT, TYPE_DATA_INPUT);
+
+    private static final Map<TypeDescription, String> METHOD_NAMES;
+    static {
+        Map<TypeDescription, String> map = new HashMap<>();
+        map.put(Descriptions.typeOf(BooleanOption.class), "compareBoolean");
+        map.put(Descriptions.typeOf(ByteOption.class), "compareByte");
+        map.put(Descriptions.typeOf(ShortOption.class), "compareShort");
+        map.put(Descriptions.typeOf(IntOption.class), "compareInt");
+        map.put(Descriptions.typeOf(LongOption.class), "compareLong");
+        map.put(Descriptions.typeOf(FloatOption.class), "compareFloat");
+        map.put(Descriptions.typeOf(DoubleOption.class), "compareDouble");
+        map.put(Descriptions.typeOf(DecimalOption.class), "compareDecimal");
+        map.put(Descriptions.typeOf(DateOption.class), "compareDate");
+        map.put(Descriptions.typeOf(DateTimeOption.class), "compareDateTime");
+        map.put(Descriptions.typeOf(StringOption.class), "compareString");
+        METHOD_NAMES = Collections.unmodifiableMap(map);
+    }
+
+    private DataComparatorGenerator() {
+        return;
+    }
+
+    /**
+     * Generates {@link DataComparator} class.
+     * @param context the current context
+     * @param type the target data model type
+     * @param orderings the ordering terms
+     * @return the generated class
+     */
+    public static ClassDescription get(
+            ClassGeneratorContext context, TypeDescription type, List<Group.Ordering> orderings) {
+        return context.addClassFile(generate(context, type, orderings));
+    }
+
+    /**
+     * Generates {@link DataComparator} class.
+     * @param context the current context
+     * @param type the target data model type
+     * @param orderings the ordering terms
+     * @return the generated class data
+     */
+    public static ClassData generate(
+            ClassGeneratorContext context, TypeDescription type, List<Group.Ordering> orderings) {
+        return context.cache(new Key(type, orderings), () -> {
+            DataModelReference ref = context.getDataModelLoader().load(type);
+            ClassDescription target = context.getClassName(CATEGORY, NameUtil.getSimpleNameHint(type, SUFFIX));
+            return generate0(ref, orderings, target);
+        });
+    }
+
+    private static ClassData generate0(
+            DataModelReference reference, List<Group.Ordering> orderings, ClassDescription target) {
+        ClassWriter writer = newWriter(target, Object.class, DataComparator.class);
+        defineEmptyConstructor(writer, Object.class);
+        defineCompare(writer, reference, orderings);
+        writer.visitEnd();
+        return new ClassData(target, writer::toByteArray);
+    }
+
+    private static void defineCompare(
+            ClassWriter writer, DataModelReference reference, List<Group.Ordering> orderings) {
+        MethodVisitor v = writer.visitMethod(
+                Opcodes.ACC_PUBLIC,
+                "compare",
+                DESC_COMPARE,
+                null,
+                new String[] {
+                        typeOf(IOException.class).getInternalName(),
+                });
+        LocalVarRef a = new LocalVarRef(Opcodes.ALOAD, 1);
+        LocalVarRef b = new LocalVarRef(Opcodes.ALOAD, 2);
+        for (Group.Ordering ordering : orderings) {
+            PropertyReference property = Invariants.requireNonNull(reference.findProperty(ordering.getPropertyName()));
+
+            // int diff = ValueOptionSerDe.compareT({a, b}, {b, a});
+            switch (ordering.getDirection()) {
+            case ASCENDANT:
+                a.load(v);
+                b.load(v);
+                break;
+            case DESCENDANT:
+                b.load(v);
+                a.load(v);
+                break;
+            default:
+                throw new AssertionError(ordering);
+            }
+            v.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    typeOf(ValueOptionSerDe.class).getInternalName(),
+                    Invariants.requireNonNull(METHOD_NAMES.get(property.getType())),
+                    DESC_COMPARE,
+                    false);
+            LocalVarRef cmp = putLocalVar(v, Type.INT, 3);
+            Label eq = new Label();
+
+            // if (diff != 0) {
+            cmp.load(v);
+            v.visitJumpInsn(Opcodes.IFEQ, eq);
+
+            // return diff;
+            cmp.load(v);
+            v.visitInsn(Opcodes.IRETURN);
+
+            // } @ eq
+            v.visitLabel(eq);
+        }
+        getConst(v, 0);
+        v.visitInsn(Opcodes.IRETURN);
+        v.visitMaxs(0, 0);
+        v.visitEnd();
+    }
+
+    private static class Key {
+
+        private final TypeDescription type;
+
+        private final List<Group.Ordering> orderings;
+
+        Key(TypeDescription type, List<Group.Ordering> orderings) {
+            this.type = type;
+            this.orderings = Arguments.freeze(orderings);
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = Key.class.hashCode();
+            result = prime * result + Objects.hashCode(type);
+            result = prime * result + Objects.hashCode(orderings);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Key other = (Key) obj;
+            if (!Objects.equals(type, other.type)) {
+                return false;
+            }
+            if (!Objects.equals(orderings, other.orderings)) {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/KeyValueSerDeGenerator.java
+++ b/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/KeyValueSerDeGenerator.java
@@ -238,7 +238,7 @@ public final class KeyValueSerDeGenerator {
         @Override
         public int hashCode() {
             final int prime = 31;
-            int result = 1;
+            int result = Key.class.hashCode();
             result = prime * result + Objects.hashCode(type);
             result = prime * result + Objects.hashCode(group);
             return result;

--- a/compiler/codegen/src/test/java/com/asakusafw/dag/compiler/codegen/DataComparatorGeneratorTest.java
+++ b/compiler/codegen/src/test/java/com/asakusafw/dag/compiler/codegen/DataComparatorGeneratorTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.compiler.codegen;
+
+import static com.asakusafw.lang.compiler.model.description.Descriptions.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import com.asakusafw.dag.api.common.DataComparator;
+import com.asakusafw.dag.api.common.KeyValueSerDe;
+import com.asakusafw.dag.compiler.model.ClassData;
+import com.asakusafw.dag.runtime.testing.MockDataModel;
+import com.asakusafw.dag.runtime.testing.MockKeyValueModel;
+import com.asakusafw.dag.utils.common.Lang;
+import com.asakusafw.lang.compiler.model.description.ClassDescription;
+import com.asakusafw.lang.compiler.model.graph.Group;
+import com.asakusafw.runtime.io.util.DataBuffer;
+
+/**
+ * Test for {@link DataComparatorGenerator}.
+ */
+public class DataComparatorGeneratorTest extends ClassGeneratorTestRoot {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        test(group("=key", "+sort"), model(0, "1.0", "A"), model(1, "1.0", "B"), equalTo(0));
+        test(group("=key", "+sort"), model(0, "1.0", "A"), model(1, "2.0", "B"), lessThan(0));
+        test(group("=key", "-sort"), model(0, "1.0", "A"), model(1, "2.0", "B"), greaterThan(0));
+    }
+
+    /**
+     * w/ multiple entries.
+     */
+    @Test
+    public void multiple() {
+        test(group("+key", "+sort", "-value"), model(0, "1.0", "A"), model(1, "1.0", "A"), lessThan(0));
+        test(group("+key", "+sort", "-value"), model(0, "1.0", "A"), model(0, "2.0", "A"), lessThan(0));
+        test(group("+key", "+sort", "-value"), model(0, "1.0", "A"), model(0, "1.0", "B"), greaterThan(0));
+        test(group("+key", "+sort", "-value"), model(0, "1.0", "A"), model(0, "1.0", "A"), equalTo(0));
+    }
+
+    /**
+     * cache - equivalent.
+     */
+    @Test
+    public void cache() {
+        ClassData a = DataComparatorGenerator.generate(context(), typeOf(MockDataModel.class), order("+sort"));
+        ClassData b = DataComparatorGenerator.generate(context(), typeOf(MockDataModel.class), order("+sort"));
+        assertThat(b, is(cacheOf(a)));
+    }
+
+    /**
+     * cache - trivial.
+     */
+    @Test
+    public void cache_trivial() {
+        ClassData a = DataComparatorGenerator.generate(context(), typeOf(MockDataModel.class), order());
+        ClassData b = DataComparatorGenerator.generate(context(), typeOf(MockDataModel.class), order());
+        assertThat(b, is(cacheOf(a)));
+    }
+
+    /**
+     * cache w/ different types.
+     */
+    @Test
+    public void cache_diff_type() {
+        ClassData a = DataComparatorGenerator.generate(context(), typeOf(MockDataModel.class), order("+key"));
+        ClassData b = DataComparatorGenerator.generate(context(), typeOf(MockKeyValueModel.class), order("+key"));
+        assertThat(b, is(not(cacheOf(a))));
+    }
+
+    /**
+     * cache w/ different groupings.
+     */
+    @Test
+    public void cache_diff_group() {
+        ClassData a = DataComparatorGenerator.generate(context(), typeOf(MockDataModel.class), order("+sort"));
+        ClassData b = DataComparatorGenerator.generate(context(), typeOf(MockDataModel.class), order("-sort"));
+        assertThat(b, is(not(cacheOf(a))));
+    }
+
+    private MockDataModel model(int key, String sort, String value) {
+        return new MockDataModel(key, sort == null ? null : new BigDecimal(sort), value);
+    }
+
+    private void test(Group group, MockDataModel a, MockDataModel b, Matcher<Integer> predicate) {
+        ClassDescription type = classOf(MockDataModel.class);
+        ClassDescription serializer = KeyValueSerDeGenerator.get(context(), type, group);
+        ClassDescription comparator = DataComparatorGenerator.get(context(), type, group.getOrdering());
+        loading(cl -> {
+            KeyValueSerDe ser = (KeyValueSerDe) serializer.resolve(cl).newInstance();
+            DataBuffer aBuf = serialize(ser, a);
+            DataBuffer bBuf = serialize(ser, b);
+
+            DataComparator cmp = (DataComparator) comparator.resolve(cl).newInstance();
+            assertThat(cmp.compare(aBuf, bBuf), predicate);
+        });
+
+    }
+
+    private DataBuffer serialize(KeyValueSerDe ser, MockDataModel object) {
+        return Lang.safe(() -> {
+            DataBuffer buffer = new DataBuffer();
+            ser.serializeValue(object, buffer);
+            return buffer;
+        });
+    }
+
+
+    private List<Group.Ordering> order(String... expressions) {
+        Group group = group(expressions);
+        assertThat(group.getGrouping(), hasSize(0));
+        return group.getOrdering();
+    }
+}

--- a/runtime/api/src/main/java/com/asakusafw/dag/api/common/DataComparator.java
+++ b/runtime/api/src/main/java/com/asakusafw/dag/api/common/DataComparator.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.api.common;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+/**
+ * Compares serialized data sequences.
+ * @since 0.2.0
+ */
+@FunctionalInterface
+public interface DataComparator {
+
+    /**
+     * Compares between the two serialized data sequences in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     */
+    int compare(DataInput a, DataInput b) throws IOException;
+}

--- a/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/io/ValueOptionSerDe.java
+++ b/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/io/ValueOptionSerDe.java
@@ -42,6 +42,8 @@ import com.asakusafw.runtime.value.ValueOption;
 
 /**
  * Serializes/deserializes {@link ValueOption} objects.
+ * @since 0.1.0
+ * @version 0.2.0
  */
 @SuppressWarnings("deprecation")
 public final class ValueOptionSerDe {
@@ -140,6 +142,22 @@ public final class ValueOptionSerDe {
     }
 
     /**
+     * Compares two serialized {@link BooleanOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareBoolean(DataInput a, DataInput b) throws IOException {
+        byte aValue = a.readByte();
+        byte bValue = b.readByte();
+        return Byte.compare(aValue, bValue);
+    }
+
+    /**
      * Serializes {@link ByteOption} object.
      * @param option the target object
      * @param output the target output
@@ -167,6 +185,35 @@ public final class ValueOptionSerDe {
         } else {
             option.modify(input.readByte());
         }
+    }
+
+    /**
+     * Compares two serialized {@link ByteOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareByte(DataInput a, DataInput b) throws IOException {
+        byte aHeader = a.readByte();
+        byte bHeader = b.readByte();
+        if (aHeader == NULL_HEADER) {
+            if (bHeader == NULL_HEADER) {
+                return 0;
+            } else {
+                skip(b, Byte.BYTES);
+                return -1;
+            }
+        } else if (bHeader == NULL_HEADER) {
+            skip(a, Byte.BYTES);
+            return +1;
+        }
+        byte aValue = a.readByte();
+        byte bValue = b.readByte();
+        return Byte.compare(aValue, bValue);
     }
 
     /**
@@ -200,6 +247,35 @@ public final class ValueOptionSerDe {
     }
 
     /**
+     * Compares two serialized {@link ShortOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareShort(DataInput a, DataInput b) throws IOException {
+        byte aHeader = a.readByte();
+        byte bHeader = b.readByte();
+        if (aHeader == NULL_HEADER) {
+            if (bHeader == NULL_HEADER) {
+                return 0;
+            } else {
+                skip(b, Short.BYTES);
+                return -1;
+            }
+        } else if (bHeader == NULL_HEADER) {
+            skip(a, Short.BYTES);
+            return +1;
+        }
+        short aValue = a.readShort();
+        short bValue = b.readShort();
+        return Short.compare(aValue, bValue);
+    }
+
+    /**
      * Serializes {@link IntOption} object.
      * @param option the target object
      * @param output the target output
@@ -227,6 +303,35 @@ public final class ValueOptionSerDe {
         } else {
             option.modify(input.readInt());
         }
+    }
+
+    /**
+     * Compares two serialized {@link IntOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareInt(DataInput a, DataInput b) throws IOException {
+        byte aHeader = a.readByte();
+        byte bHeader = b.readByte();
+        if (aHeader == NULL_HEADER) {
+            if (bHeader == NULL_HEADER) {
+                return 0;
+            } else {
+                skip(b, Integer.BYTES);
+                return -1;
+            }
+        } else if (bHeader == NULL_HEADER) {
+            skip(a, Integer.BYTES);
+            return +1;
+        }
+        int aValue = a.readInt();
+        int bValue = b.readInt();
+        return Integer.compare(aValue, bValue);
     }
 
     /**
@@ -260,6 +365,35 @@ public final class ValueOptionSerDe {
     }
 
     /**
+     * Compares two serialized {@link LongOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareLong(DataInput a, DataInput b) throws IOException {
+        byte aHeader = a.readByte();
+        byte bHeader = b.readByte();
+        if (aHeader == NULL_HEADER) {
+            if (bHeader == NULL_HEADER) {
+                return 0;
+            } else {
+                skip(b, Long.BYTES);
+                return -1;
+            }
+        } else if (bHeader == NULL_HEADER) {
+            skip(a, Long.BYTES);
+            return +1;
+        }
+        long aValue = a.readLong();
+        long bValue = b.readLong();
+        return Long.compare(aValue, bValue);
+    }
+
+    /**
      * Serializes {@link FloatOption} object.
      * @param option the target object
      * @param output the target output
@@ -287,6 +421,35 @@ public final class ValueOptionSerDe {
         } else {
             option.modify(input.readFloat());
         }
+    }
+
+    /**
+     * Compares two serialized {@link FloatOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareFloat(DataInput a, DataInput b) throws IOException {
+        byte aHeader = a.readByte();
+        byte bHeader = b.readByte();
+        if (aHeader == NULL_HEADER) {
+            if (bHeader == NULL_HEADER) {
+                return 0;
+            } else {
+                skip(b, Float.BYTES);
+                return -1;
+            }
+        } else if (bHeader == NULL_HEADER) {
+            skip(a, Float.BYTES);
+            return +1;
+        }
+        float aValue = a.readFloat();
+        float bValue = b.readFloat();
+        return Float.compare(aValue, bValue);
     }
 
     /**
@@ -320,6 +483,35 @@ public final class ValueOptionSerDe {
     }
 
     /**
+     * Compares two serialized {@link DoubleOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareDouble(DataInput a, DataInput b) throws IOException {
+        byte aHeader = a.readByte();
+        byte bHeader = b.readByte();
+        if (aHeader == NULL_HEADER) {
+            if (bHeader == NULL_HEADER) {
+                return 0;
+            } else {
+                skip(b, Double.BYTES);
+                return -1;
+            }
+        } else if (bHeader == NULL_HEADER) {
+            skip(a, Double.BYTES);
+            return +1;
+        }
+        double aValue = a.readDouble();
+        double bValue = b.readDouble();
+        return Double.compare(aValue, bValue);
+    }
+
+    /**
      * Serializes {@link DateOption} object.
      * @param option the target object
      * @param output the target output
@@ -350,6 +542,22 @@ public final class ValueOptionSerDe {
     }
 
     /**
+     * Compares two serialized {@link DateOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareDate(DataInput a, DataInput b) throws IOException {
+        int aValue = a.readInt();
+        int bValue = b.readInt();
+        return Integer.compare(aValue, bValue);
+    }
+
+    /**
      * Serializes {@link DateTimeOption} object.
      * @param option the target object
      * @param output the target output
@@ -377,6 +585,22 @@ public final class ValueOptionSerDe {
         } else {
             option.modify(value);
         }
+    }
+
+    /**
+     * Compares two serialized {@link DateTimeOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareDateTime(DataInput a, DataInput b) throws IOException {
+        long aValue = a.readLong();
+        long bValue = b.readLong();
+        return Long.compare(aValue, bValue);
     }
 
     /**
@@ -421,6 +645,70 @@ public final class ValueOptionSerDe {
             byte[] buffer = getLocalBuffer(length, Integer.MAX_VALUE);
             input.readFully(buffer, 0, length);
             option.modify(buffer, 0, length);
+        }
+    }
+
+    /**
+     * Compares two serialized {@link StringOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareString(DataInput a, DataInput b) throws IOException {
+        int aLength = readCompactInt(a);
+        int bLength = readCompactInt(b);
+        if (aLength == UNSIGNED_NULL) {
+            if (bLength == UNSIGNED_NULL) {
+                return 0;
+            } else {
+                skip(b, bLength);
+                return -1;
+            }
+        } else if (bLength == UNSIGNED_NULL) {
+            skip(a, aLength);
+            return +1;
+        }
+        for (int i = 0, n = Math.min(aLength, bLength); i < n; i++) {
+            int aChar = Byte.toUnsignedInt(a.readByte());
+            int bChar = Byte.toUnsignedInt(b.readByte());
+            if (aChar != bChar) {
+                skip(a, aLength - (i + 1));
+                skip(b, bLength - (i + 1));
+                if (aChar < bChar) {
+                    return -1;
+                } else {
+                    return +1;
+                }
+            }
+        }
+        if (aLength == bLength) {
+            return 0;
+        } else if (aLength < bLength) {
+            skip(b, bLength - aLength);
+            return -1;
+        } else {
+            skip(a, aLength - bLength);
+            return +1;
+        }
+    }
+
+    private static void skip(DataInput input, int length) throws IOException {
+        if (length == 0) {
+            return;
+        }
+        int rest = length;
+        while (rest > 0) {
+            int skipped = input.skipBytes(rest);
+            if (skipped <= 0) {
+                input.readByte();
+                rest--;
+            } else {
+                rest -= skipped;
+            }
         }
     }
 
@@ -474,10 +762,35 @@ public final class ValueOptionSerDe {
      * @throws IOException if I/O error was occurred while deserializing the object
      */
     public static void deserialize(DecimalOption option, DataInput input) throws IOException {
+        option.modify(deserializeDecimal(input));
+    }
+
+    /**
+     * Compares two serialized {@link DecimalOption}s in each given {@link DataInput}.
+     * @param a the first {@link DataInput}
+     * @param b the second {@link DataInput}
+     * @return {@code 0} - the two values are both equivalent,
+     *   {@code < 0} - the first value is less than the second one, or
+     *   {@code > 0} - the second value is less than the second one
+     * @throws IOException if I/O error was occurred while comparing the values
+     * @since 0.2.0
+     */
+    public static int compareDecimal(DataInput a, DataInput b) throws IOException {
+        BigDecimal aValue = deserializeDecimal(a);
+        BigDecimal bValue = deserializeDecimal(b);
+        if (aValue == null) {
+            return bValue == null ? 0 : -1;
+        } else if (bValue == null) {
+            return +1;
+        } else {
+            return aValue.compareTo(bValue);
+        }
+    }
+
+    private static BigDecimal deserializeDecimal(DataInput input) throws IOException {
         byte head = input.readByte();
         if (head == DECIMAL_NULL) {
-            option.setNull();
-            return;
+            return null;
         }
         boolean compact = (head & DECIMAL_COMPACT_MASK) != 0;
         boolean plus = (head & DECIMAL_PLUS_MASK) != 0;
@@ -485,7 +798,7 @@ public final class ValueOptionSerDe {
         if (compact) {
             long unscaled = readCompactLong(input);
             assert unscaled >= 0;
-            option.modify(BigDecimal.valueOf(plus ? unscaled : -unscaled, scale));
+            return BigDecimal.valueOf(plus ? unscaled : -unscaled, scale);
         } else {
             int length = readCompactInt(input);
             assert length != 0; // '0' must be compact form
@@ -495,7 +808,7 @@ public final class ValueOptionSerDe {
             if (offset > 0) {
                 Arrays.fill(buffer, 0, offset, (byte) 0);
             }
-            option.modify(new BigDecimal(new BigInteger(plus ? +1 : -1, buffer), scale));
+            return new BigDecimal(new BigInteger(plus ? +1 : -1, buffer), scale);
         }
     }
 

--- a/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/io/SerDeNativeTest.java
+++ b/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/io/SerDeNativeTest.java
@@ -17,6 +17,7 @@ package com.asakusafw.dag.runtime.io;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
 
 import java.io.DataOutput;
 import java.io.File;
@@ -155,14 +156,14 @@ public class SerDeNativeTest {
     public void compare_boolean() throws Exception {
         Comparator<BooleanOption> cmp = comparator(MAPPER::jna_compare_boolean);
 
-        assertThat(cmp.compare(new BooleanOption(false), new BooleanOption(false)), is(0));
-        assertThat(cmp.compare(new BooleanOption(true), new BooleanOption(true)), is(0));
-        assertThat(cmp.compare(new BooleanOption(true), new BooleanOption(false)), greaterThan(0));
-        assertThat(cmp.compare(new BooleanOption(false), new BooleanOption(true)), lessThan(0));
+        compare(cmp, new BooleanOption(false), new BooleanOption(false));
+        compare(cmp, new BooleanOption(true), new BooleanOption(true));
+        compare(cmp, new BooleanOption(true), new BooleanOption(false));
+        compare(cmp, new BooleanOption(false), new BooleanOption(true));
 
-        assertThat(cmp.compare(new BooleanOption(), new BooleanOption()), is(0));
-        assertThat(cmp.compare(new BooleanOption(false), new BooleanOption()), greaterThan(0));
-        assertThat(cmp.compare(new BooleanOption(), new BooleanOption(false)), lessThan(0));
+        compare(cmp, new BooleanOption(), new BooleanOption());
+        compare(cmp, new BooleanOption(false), new BooleanOption());
+        compare(cmp, new BooleanOption(), new BooleanOption(false));
     }
 
     /**
@@ -173,13 +174,13 @@ public class SerDeNativeTest {
     public void compare_byte() throws Exception {
         Comparator<ByteOption> cmp = comparator(MAPPER::jna_compare_byte);
 
-        assertThat(cmp.compare(new ByteOption((byte) 0), new ByteOption((byte) 0)), is(0));
-        assertThat(cmp.compare(new ByteOption((byte) 1), new ByteOption((byte) 0)), greaterThan(0));
-        assertThat(cmp.compare(new ByteOption((byte) 0), new ByteOption((byte) 1)), lessThan(0));
+        compare(cmp, new ByteOption((byte) 0), new ByteOption((byte) 0));
+        compare(cmp, new ByteOption((byte) 1), new ByteOption((byte) 0));
+        compare(cmp, new ByteOption((byte) 0), new ByteOption((byte) 1));
 
-        assertThat(cmp.compare(new ByteOption(), new ByteOption()), is(0));
-        assertThat(cmp.compare(new ByteOption((byte) -1), new ByteOption()), greaterThan(0));
-        assertThat(cmp.compare(new ByteOption(), new ByteOption((byte) -1)), lessThan(0));
+        compare(cmp, new ByteOption(), new ByteOption());
+        compare(cmp, new ByteOption((byte) -1), new ByteOption());
+        compare(cmp, new ByteOption(), new ByteOption((byte) -1));
     }
 
     /**
@@ -190,13 +191,13 @@ public class SerDeNativeTest {
     public void compare_short() throws Exception {
         Comparator<ShortOption> cmp = comparator(MAPPER::jna_compare_short);
 
-        assertThat(cmp.compare(new ShortOption((short) 0), new ShortOption((short) 0)), is(0));
-        assertThat(cmp.compare(new ShortOption((short) 1), new ShortOption((short) 0)), greaterThan(0));
-        assertThat(cmp.compare(new ShortOption((short) 0), new ShortOption((short) 1)), lessThan(0));
+        compare(cmp, new ShortOption((short) 0), new ShortOption((short) 0));
+        compare(cmp, new ShortOption((short) 1), new ShortOption((short) 0));
+        compare(cmp, new ShortOption((short) 0), new ShortOption((short) 1));
 
-        assertThat(cmp.compare(new ShortOption(), new ShortOption()), is(0));
-        assertThat(cmp.compare(new ShortOption((short) -1), new ShortOption()), greaterThan(0));
-        assertThat(cmp.compare(new ShortOption(), new ShortOption((short) -1)), lessThan(0));
+        compare(cmp, new ShortOption(), new ShortOption());
+        compare(cmp, new ShortOption((short) -1), new ShortOption());
+        compare(cmp, new ShortOption(), new ShortOption((short) -1));
     }
 
     /**
@@ -207,13 +208,13 @@ public class SerDeNativeTest {
     public void compare_int() throws Exception {
         Comparator<IntOption> cmp = comparator(MAPPER::jna_compare_int);
 
-        assertThat(cmp.compare(new IntOption(0), new IntOption(0)), is(0));
-        assertThat(cmp.compare(new IntOption(1), new IntOption(0)), greaterThan(0));
-        assertThat(cmp.compare(new IntOption(0), new IntOption(1)), lessThan(0));
+        compare(cmp, new IntOption(0), new IntOption(0));
+        compare(cmp, new IntOption(1), new IntOption(0));
+        compare(cmp, new IntOption(0), new IntOption(1));
 
-        assertThat(cmp.compare(new IntOption(), new IntOption()), is(0));
-        assertThat(cmp.compare(new IntOption(-1), new IntOption()), greaterThan(0));
-        assertThat(cmp.compare(new IntOption(), new IntOption(-1)), lessThan(0));
+        compare(cmp, new IntOption(), new IntOption());
+        compare(cmp, new IntOption(-1), new IntOption());
+        compare(cmp, new IntOption(), new IntOption(-1));
     }
 
     /**
@@ -224,13 +225,13 @@ public class SerDeNativeTest {
     public void compare_long() throws Exception {
         Comparator<LongOption> cmp = comparator(MAPPER::jna_compare_long);
 
-        assertThat(cmp.compare(new LongOption(0), new LongOption(0)), is(0));
-        assertThat(cmp.compare(new LongOption(1), new LongOption(0)), greaterThan(0));
-        assertThat(cmp.compare(new LongOption(0), new LongOption(1)), lessThan(0));
+        compare(cmp, new LongOption(0), new LongOption(0));
+        compare(cmp, new LongOption(1), new LongOption(0));
+        compare(cmp, new LongOption(0), new LongOption(1));
 
-        assertThat(cmp.compare(new LongOption(), new LongOption()), is(0));
-        assertThat(cmp.compare(new LongOption(-1), new LongOption()), greaterThan(0));
-        assertThat(cmp.compare(new LongOption(), new LongOption(-1)), lessThan(0));
+        compare(cmp, new LongOption(), new LongOption());
+        compare(cmp, new LongOption(-1), new LongOption());
+        compare(cmp, new LongOption(), new LongOption(-1));
     }
 
     /**
@@ -241,13 +242,13 @@ public class SerDeNativeTest {
     public void compare_float() throws Exception {
         Comparator<FloatOption> cmp = comparator(MAPPER::jna_compare_float);
 
-        assertThat(cmp.compare(new FloatOption(0), new FloatOption(0)), is(0));
-        assertThat(cmp.compare(new FloatOption(1), new FloatOption(0)), greaterThan(0));
-        assertThat(cmp.compare(new FloatOption(0), new FloatOption(1)), lessThan(0));
+        compare(cmp, new FloatOption(0), new FloatOption(0));
+        compare(cmp, new FloatOption(1), new FloatOption(0));
+        compare(cmp, new FloatOption(0), new FloatOption(1));
 
-        assertThat(cmp.compare(new FloatOption(), new FloatOption()), is(0));
-        assertThat(cmp.compare(new FloatOption(-1), new FloatOption()), greaterThan(0));
-        assertThat(cmp.compare(new FloatOption(), new FloatOption(-1)), lessThan(0));
+        compare(cmp, new FloatOption(), new FloatOption());
+        compare(cmp, new FloatOption(-1), new FloatOption());
+        compare(cmp, new FloatOption(), new FloatOption(-1));
     }
 
     /**
@@ -258,13 +259,13 @@ public class SerDeNativeTest {
     public void compare_double() throws Exception {
         Comparator<DoubleOption> cmp = comparator(MAPPER::jna_compare_double);
 
-        assertThat(cmp.compare(new DoubleOption(0), new DoubleOption(0)), is(0));
-        assertThat(cmp.compare(new DoubleOption(1), new DoubleOption(0)), greaterThan(0));
-        assertThat(cmp.compare(new DoubleOption(0), new DoubleOption(1)), lessThan(0));
+        compare(cmp, new DoubleOption(0), new DoubleOption(0));
+        compare(cmp, new DoubleOption(1), new DoubleOption(0));
+        compare(cmp, new DoubleOption(0), new DoubleOption(1));
 
-        assertThat(cmp.compare(new DoubleOption(), new DoubleOption()), is(0));
-        assertThat(cmp.compare(new DoubleOption(-1), new DoubleOption()), greaterThan(0));
-        assertThat(cmp.compare(new DoubleOption(), new DoubleOption(-1)), lessThan(0));
+        compare(cmp, new DoubleOption(), new DoubleOption());
+        compare(cmp, new DoubleOption(-1), new DoubleOption());
+        compare(cmp, new DoubleOption(), new DoubleOption(-1));
     }
 
     /**
@@ -275,13 +276,13 @@ public class SerDeNativeTest {
     public void compare_date() throws Exception {
         Comparator<DateOption> cmp = comparator(MAPPER::jna_compare_date);
 
-        assertThat(cmp.compare(newDate(0), newDate(0)), is(0));
-        assertThat(cmp.compare(newDate(1), newDate(0)), greaterThan(0));
-        assertThat(cmp.compare(newDate(0), newDate(1)), lessThan(0));
+        compare(cmp, newDate(0), newDate(0));
+        compare(cmp, newDate(1), newDate(0));
+        compare(cmp, newDate(0), newDate(1));
 
-        assertThat(cmp.compare(new DateOption(), new DateOption()), is(0));
-        assertThat(cmp.compare(newDate(0), new DateOption()), greaterThan(0));
-        assertThat(cmp.compare(new DateOption(), newDate(0)), lessThan(0));
+        compare(cmp, new DateOption(), new DateOption());
+        compare(cmp, newDate(0), new DateOption());
+        compare(cmp, new DateOption(), newDate(0));
     }
 
     /**
@@ -292,13 +293,13 @@ public class SerDeNativeTest {
     public void compare_date_time() throws Exception {
         Comparator<DateTimeOption> cmp = comparator(MAPPER::jna_compare_date_time);
 
-        assertThat(cmp.compare(newDateTime(0), newDateTime(0)), is(0));
-        assertThat(cmp.compare(newDateTime(1), newDateTime(0)), greaterThan(0));
-        assertThat(cmp.compare(newDateTime(0), newDateTime(1)), lessThan(0));
+        compare(cmp, newDateTime(0), newDateTime(0));
+        compare(cmp, newDateTime(1), newDateTime(0));
+        compare(cmp, newDateTime(0), newDateTime(1));
 
-        assertThat(cmp.compare(new DateTimeOption(), new DateTimeOption()), is(0));
-        assertThat(cmp.compare(newDateTime(0), new DateTimeOption()), greaterThan(0));
-        assertThat(cmp.compare(new DateTimeOption(), newDateTime(0)), lessThan(0));
+        compare(cmp, new DateTimeOption(), new DateTimeOption());
+        compare(cmp, newDateTime(0), new DateTimeOption());
+        compare(cmp, new DateTimeOption(), newDateTime(0));
     }
 
     /**
@@ -309,17 +310,17 @@ public class SerDeNativeTest {
     public void compare_string() throws Exception {
         Comparator<StringOption> cmp = comparator(MAPPER::jna_compare_string);
 
-        assertThat(cmp.compare(new StringOption("a"), new StringOption("a")), is(0));
-        assertThat(cmp.compare(new StringOption("b"), new StringOption("a")), greaterThan(0));
-        assertThat(cmp.compare(new StringOption("a"), new StringOption("b")), lessThan(0));
+        compare(cmp, new StringOption("a"), new StringOption("a"));
+        compare(cmp, new StringOption("b"), new StringOption("a"));
+        compare(cmp, new StringOption("a"), new StringOption("b"));
 
-        assertThat(cmp.compare(new StringOption("AAA"), new StringOption("AAA")), is(0));
-        assertThat(cmp.compare(new StringOption("ABA"), new StringOption("AAB")), greaterThan(0));
-        assertThat(cmp.compare(new StringOption("AAB"), new StringOption("ABA")), lessThan(0));
+        compare(cmp, new StringOption("AAA"), new StringOption("AAA"));
+        compare(cmp, new StringOption("ABA"), new StringOption("AAB"));
+        compare(cmp, new StringOption("AAB"), new StringOption("ABA"));
 
-        assertThat(cmp.compare(new StringOption(), new StringOption()), is(0));
-        assertThat(cmp.compare(new StringOption("a"), new StringOption()), greaterThan(0));
-        assertThat(cmp.compare(new StringOption(), new StringOption("a")), lessThan(0));
+        compare(cmp, new StringOption(), new StringOption());
+        compare(cmp, new StringOption("a"), new StringOption());
+        compare(cmp, new StringOption(), new StringOption("a"));
     }
 
     /**
@@ -330,21 +331,21 @@ public class SerDeNativeTest {
     public void compare_decimal() throws Exception {
         Comparator<DecimalOption> cmp = comparator(MAPPER::jna_compare_decimal);
 
-        assertThat(cmp.compare(newDecimal("1"), newDecimal("1")), is(0));
-        assertThat(cmp.compare(newDecimal("1.1"), newDecimal("1")), greaterThan(0));
-        assertThat(cmp.compare(newDecimal("1.10"), newDecimal("1")), greaterThan(0));
-        assertThat(cmp.compare(newDecimal("1.10"), newDecimal("2")), lessThan(0));
-        assertThat(cmp.compare(newDecimal("1"), newDecimal("1.1")), lessThan(0));
-        assertThat(cmp.compare(newDecimal("1"), newDecimal("1.10")), lessThan(0));
-        assertThat(cmp.compare(newDecimal("2"), newDecimal("1.10")), greaterThan(0));
+        compare(cmp, newDecimal("1"), newDecimal("1"));
+        compare(cmp, newDecimal("1.1"), newDecimal("1"));
+        compare(cmp, newDecimal("1.10"), newDecimal("1"));
+        compare(cmp, newDecimal("1.10"), newDecimal("2"));
+        compare(cmp, newDecimal("1"), newDecimal("1.1"));
+        compare(cmp, newDecimal("1"), newDecimal("1.10"));
+        compare(cmp, newDecimal("2"), newDecimal("1.10"));
 
-        assertThat(cmp.compare(newDecimal("1"), newDecimal("1")), is(0));
-        assertThat(cmp.compare(newDecimal("1"), newDecimal("-1")), greaterThan(0));
-        assertThat(cmp.compare(newDecimal("-1"), newDecimal("1")), lessThan(0));
+        compare(cmp, newDecimal("1"), newDecimal("1"));
+        compare(cmp, newDecimal("1"), newDecimal("-1"));
+        compare(cmp, newDecimal("-1"), newDecimal("1"));
 
-        assertThat(cmp.compare(new DecimalOption(), new DecimalOption()), is(0));
-        assertThat(cmp.compare(newDecimal("1.1"), new DecimalOption()), greaterThan(0));
-        assertThat(cmp.compare(new DecimalOption(), newDecimal("1.1")), lessThan(0));
+        compare(cmp, new DecimalOption(), new DecimalOption());
+        compare(cmp, newDecimal("1.1"), new DecimalOption());
+        compare(cmp, new DecimalOption(), newDecimal("1.1"));
     }
 
     private DateOption newDate(int v) {
@@ -357,6 +358,18 @@ public class SerDeNativeTest {
 
     private DecimalOption newDecimal(String v) {
         return new DecimalOption(new BigDecimal(v));
+    }
+
+    private static <T extends Comparable<? super T>> void compare(Comparator<T> cmp, T a, T b) {
+        int sign = a.compareTo(b);
+        int result = cmp.compare(a, b);
+        if (sign == 0) {
+            assertThat(result, equalTo(0));
+        } else if (sign < 0) {
+            assertThat(result, lessThan(0));
+        } else {
+            assertThat(result, greaterThan(0));
+        }
     }
 
     private <T extends ValueOption<?>> Comparator<T> comparator(BiFunction<Pointer, Pointer, Integer> func) {

--- a/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/io/ValueOptionSerDeTest.java
+++ b/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/io/ValueOptionSerDeTest.java
@@ -15,7 +15,7 @@
  */
 package com.asakusafw.dag.runtime.io;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.DataInput;
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 
 import org.junit.Test;
 
+import com.asakusafw.dag.api.common.DataComparator;
 import com.asakusafw.runtime.io.util.DataBuffer;
 import com.asakusafw.runtime.value.BooleanOption;
 import com.asakusafw.runtime.value.ByteOption;
@@ -208,6 +209,209 @@ public class ValueOptionSerDeTest {
         check(new DecimalOption(new BigDecimal(Long.MIN_VALUE + 1).subtract(BigDecimal.ONE)));
     }
 
+    /**
+     * Test for {@link ValueOptionSerDe#compareBoolean(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_boolean() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareBoolean;
+
+        compare(cmp, new BooleanOption(false), new BooleanOption(false));
+        compare(cmp, new BooleanOption(true), new BooleanOption(true));
+        compare(cmp, new BooleanOption(true), new BooleanOption(false));
+        compare(cmp, new BooleanOption(false), new BooleanOption(true));
+
+        compare(cmp, new BooleanOption(), new BooleanOption());
+        compare(cmp, new BooleanOption(false), new BooleanOption());
+        compare(cmp, new BooleanOption(), new BooleanOption(false));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareByte(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_byte() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareByte;
+
+        compare(cmp, new ByteOption((byte) 0), new ByteOption((byte) 0));
+        compare(cmp, new ByteOption((byte) 1), new ByteOption((byte) 0));
+        compare(cmp, new ByteOption((byte) 0), new ByteOption((byte) 1));
+
+        compare(cmp, new ByteOption(), new ByteOption());
+        compare(cmp, new ByteOption((byte) -1), new ByteOption());
+        compare(cmp, new ByteOption(), new ByteOption((byte) -1));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareShort(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_short() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareShort;
+
+        compare(cmp, new ShortOption((short) 0), new ShortOption((short) 0));
+        compare(cmp, new ShortOption((short) 1), new ShortOption((short) 0));
+        compare(cmp, new ShortOption((short) 0), new ShortOption((short) 1));
+
+        compare(cmp, new ShortOption(), new ShortOption());
+        compare(cmp, new ShortOption((short) -1), new ShortOption());
+        compare(cmp, new ShortOption(), new ShortOption((short) -1));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareInt(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_int() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareInt;
+
+        compare(cmp, new IntOption(0), new IntOption(0));
+        compare(cmp, new IntOption(1), new IntOption(0));
+        compare(cmp, new IntOption(0), new IntOption(1));
+
+        compare(cmp, new IntOption(), new IntOption());
+        compare(cmp, new IntOption(-1), new IntOption());
+        compare(cmp, new IntOption(), new IntOption(-1));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareLong(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_long() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareLong;
+
+        compare(cmp, new LongOption(0), new LongOption(0));
+        compare(cmp, new LongOption(1), new LongOption(0));
+        compare(cmp, new LongOption(0), new LongOption(1));
+
+        compare(cmp, new LongOption(), new LongOption());
+        compare(cmp, new LongOption(-1), new LongOption());
+        compare(cmp, new LongOption(), new LongOption(-1));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareFloat(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_float() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareFloat;
+
+        compare(cmp, new FloatOption(0), new FloatOption(0));
+        compare(cmp, new FloatOption(1), new FloatOption(0));
+        compare(cmp, new FloatOption(0), new FloatOption(1));
+
+        compare(cmp, new FloatOption(), new FloatOption());
+        compare(cmp, new FloatOption(-1), new FloatOption());
+        compare(cmp, new FloatOption(), new FloatOption(-1));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareDouble(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_double() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareDouble;
+
+        compare(cmp, new DoubleOption(0), new DoubleOption(0));
+        compare(cmp, new DoubleOption(1), new DoubleOption(0));
+        compare(cmp, new DoubleOption(0), new DoubleOption(1));
+
+        compare(cmp, new DoubleOption(), new DoubleOption());
+        compare(cmp, new DoubleOption(-1), new DoubleOption());
+        compare(cmp, new DoubleOption(), new DoubleOption(-1));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareDate(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_date() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareDate;
+
+        compare(cmp, newDate(0), newDate(0));
+        compare(cmp, newDate(1), newDate(0));
+        compare(cmp, newDate(0), newDate(1));
+
+        compare(cmp, new DateOption(), new DateOption());
+        compare(cmp, newDate(0), new DateOption());
+        compare(cmp, new DateOption(), newDate(0));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareDateTime(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_date_time() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareDateTime;
+
+        compare(cmp, newDateTime(0), newDateTime(0));
+        compare(cmp, newDateTime(1), newDateTime(0));
+        compare(cmp, newDateTime(0), newDateTime(1));
+
+        compare(cmp, new DateTimeOption(), new DateTimeOption());
+        compare(cmp, newDateTime(0), new DateTimeOption());
+        compare(cmp, new DateTimeOption(), newDateTime(0));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareString(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_string() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareString;
+
+        compare(cmp, new StringOption("a"), new StringOption("a"));
+        compare(cmp, new StringOption("b"), new StringOption("a"));
+        compare(cmp, new StringOption("a"), new StringOption("b"));
+
+        compare(cmp, new StringOption("AAA"), new StringOption("AAA"));
+        compare(cmp, new StringOption("ABA"), new StringOption("AAB"));
+        compare(cmp, new StringOption("AAB"), new StringOption("ABA"));
+
+        compare(cmp, new StringOption("A"), new StringOption("AA"));
+        compare(cmp, new StringOption("AB"), new StringOption("ABA"));
+
+        compare(cmp, new StringOption(), new StringOption());
+        compare(cmp, new StringOption("a"), new StringOption());
+        compare(cmp, new StringOption(), new StringOption("a"));
+    }
+
+    /**
+     * Test for {@link ValueOptionSerDe#compareDecimal(DataInput, DataInput)}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compare_decimal() throws Exception {
+        DataComparator cmp = ValueOptionSerDe::compareDecimal;
+
+        compare(cmp, newDecimal("1"), newDecimal("1"));
+        compare(cmp, newDecimal("1.1"), newDecimal("1"));
+        compare(cmp, newDecimal("1.10"), newDecimal("1"));
+        compare(cmp, newDecimal("1.10"), newDecimal("2"));
+        compare(cmp, newDecimal("1"), newDecimal("1.1"));
+        compare(cmp, newDecimal("1"), newDecimal("1.10"));
+        compare(cmp, newDecimal("2"), newDecimal("1.10"));
+
+        compare(cmp, newDecimal("1"), newDecimal("1"));
+        compare(cmp, newDecimal("1"), newDecimal("-1"));
+        compare(cmp, newDecimal("-1"), newDecimal("1"));
+
+        compare(cmp, new DecimalOption(), new DecimalOption());
+        compare(cmp, newDecimal("1.1"), new DecimalOption());
+        compare(cmp, new DecimalOption(), newDecimal("1.1"));
+    }
+
     private <T extends ValueOption<T>> void check(T option) {
         try {
             ValueOption<?> copy = option.getClass().newInstance();
@@ -235,6 +439,45 @@ public class ValueOptionSerDeTest {
         try {
             ValueOptionSerDe.deserializeAny(option, input);
             return option;
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private DateOption newDate(int v) {
+        return new DateOption(new Date(v));
+    }
+
+    private DateTimeOption newDateTime(long v) {
+        return new DateTimeOption(new DateTime(v));
+    }
+
+    private DecimalOption newDecimal(String v) {
+        return new DecimalOption(new BigDecimal(v));
+    }
+
+    private <T extends ValueOption<T>> void compare(DataComparator cmp, T a, T b) {
+        compare0(cmp, a, b);
+        compare0(cmp, b, a);
+    }
+
+    private <T extends ValueOption<T>> void compare0(DataComparator cmp, T a, T b) throws AssertionError {
+        try {
+            DataBuffer aBuffer = new DataBuffer();
+            DataBuffer bBuffer = new DataBuffer();
+            ValueOptionSerDe.serializeAny(a, aBuffer);
+            ValueOptionSerDe.serializeAny(b, bBuffer);
+            int sign = a.compareTo(b);
+            int result = cmp.compare(aBuffer, bBuffer);
+            assertThat(aBuffer.getReadRemaining(), is(0));
+            assertThat(bBuffer.getReadRemaining(), is(0));
+            if (sign == 0) {
+                assertThat(result, equalTo(0));
+            } else if (sign < 0) {
+                assertThat(result, lessThan(0));
+            } else {
+                assertThat(result, greaterThan(0));
+            }
         } catch (Exception e) {
             throw new AssertionError(e);
         }


### PR DESCRIPTION
## Summary

This PR introduces a set of pure Java value comparator facilities.
## Background, Problem or Goal of the patch

The latest implementation only includes native value comparator facilities which written in C++.
## Design of the fix, or a new feature

This includes the two entry points:
- `com.asakusafw.dag.api.common.DataComparator` is an interface which compares two **serialized** value sequence
- `com.asakusafw.dag.compiler.codegen.DataComparatorGenerator` generates the above comparator implementation classes, which can compare serialized data generated by `com.asakusafw.dag.compiler.codegen.KeyValueSerDeGenerator`
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

N/A.
