### PR TITLE
Counter report entries should be sorted.

### DIFF
--- a/runtime/api/src/main/java/com/asakusafw/dag/api/counter/CounterGroup.java
+++ b/runtime/api/src/main/java/com/asakusafw/dag/api/counter/CounterGroup.java
@@ -31,22 +31,20 @@ public interface CounterGroup {
     long getCount(Column column);
 
     /**
-     * Represents a column meta-data of {@link CounterGroup}.
-     * @since 0.1.0
-     * @version 0.2.0
+     * An abstract super interface of counter elements.
+     * @since 0.2.0
      */
-    interface Column {
+    interface Element {
 
         /**
-         * Returns the description of this column.
-         * @return the description of this column
+         * Returns the description of this element.
+         * @return the description of this element
          */
         String getDescription();
 
         /**
-         * Returns the index text of this column.
+         * Returns the index text of this element.
          * @return the index text
-         * @since 0.2.0
          */
         default String getIndexText() {
             return String.format("?.%s", getDescription()); //$NON-NLS-1$
@@ -54,16 +52,21 @@ public interface CounterGroup {
     }
 
     /**
+     * Represents a column meta-data of {@link CounterGroup}.
+     * @since 0.1.0
+     * @version 0.2.0
+     */
+    interface Column extends Element {
+        // no special methods
+    }
+
+    /**
      * Represents a category of {@link CounterGroup}.
      * @param <T> the type of member {@link CounterGroup}
+     * @since 0.1.0
+     * @version 0.2.0
      */
-    interface Category<T extends CounterGroup> {
-
-        /**
-         * Returns the description of the target {@link CounterGroup}.
-         * @return the description
-         */
-        String getDescription();
+    interface Category<T extends CounterGroup> extends Element {
 
         /**
          * Returns the scope of the target {@link CounterGroup}.

--- a/runtime/api/src/main/java/com/asakusafw/dag/api/counter/CounterGroup.java
+++ b/runtime/api/src/main/java/com/asakusafw/dag/api/counter/CounterGroup.java
@@ -32,6 +32,8 @@ public interface CounterGroup {
 
     /**
      * Represents a column meta-data of {@link CounterGroup}.
+     * @since 0.1.0
+     * @version 0.2.0
      */
     interface Column {
 
@@ -40,6 +42,15 @@ public interface CounterGroup {
          * @return the description of this column
          */
         String getDescription();
+
+        /**
+         * Returns the index text of this column.
+         * @return the index text
+         * @since 0.2.0
+         */
+        default String getIndexText() {
+            return String.format("?.%s", getDescription()); //$NON-NLS-1$
+        }
     }
 
     /**

--- a/runtime/api/src/main/java/com/asakusafw/dag/api/counter/basic/BasicCounterGroupCategory.java
+++ b/runtime/api/src/main/java/com/asakusafw/dag/api/counter/basic/BasicCounterGroupCategory.java
@@ -26,6 +26,8 @@ import com.asakusafw.dag.utils.common.Arguments;
 /**
  * A basic implementation of {@link com.asakusafw.dag.api.counter.CounterGroup.Category}.
  * @param <T> the type of target {@link CounterGroup}
+ * @since 0.1.0
+ * @version 0.2.0
  */
 public class BasicCounterGroupCategory<T extends CounterGroup> implements CounterGroup.Category<T> {
 
@@ -34,6 +36,8 @@ public class BasicCounterGroupCategory<T extends CounterGroup> implements Counte
     private final Scope scope;
 
     private final List<CounterGroup.Column> columns;
+
+    private final String indexText;
 
     private final Supplier<? extends T> supplier;
 
@@ -49,13 +53,33 @@ public class BasicCounterGroupCategory<T extends CounterGroup> implements Counte
             Scope scope,
             List<? extends CounterGroup.Column> columns,
             Supplier<? extends T> provider) {
+        this(description, scope, columns, String.format("basic.%s", description), provider); //$NON-NLS-1$
+    }
+
+    /**
+     * Creates a new instance.
+     * @param description the description of the target {@link CounterGroup}
+     * @param scope the scope of the target {@link CounterGroup}
+     * @param columns the available columns in the {@link CounterGroup}
+     * @param indexText the index text
+     * @param provider a supplier which provides the target {@link CounterGroup}
+     * @since 0.2.0
+     */
+    public BasicCounterGroupCategory(
+            String description,
+            Scope scope,
+            List<? extends CounterGroup.Column> columns,
+            String indexText,
+            Supplier<? extends T> provider) {
         Arguments.requireNonNull(description);
         Arguments.requireNonNull(scope);
         Arguments.requireNonNull(columns);
+        Arguments.requireNonNull(indexText);
         Arguments.requireNonNull(provider);
         this.description = description;
         this.scope = scope;
         this.columns = Arguments.freeze(columns);
+        this.indexText = indexText;
         this.supplier = provider;
     }
 
@@ -77,6 +101,11 @@ public class BasicCounterGroupCategory<T extends CounterGroup> implements Counte
     @Override
     public T newInstance() {
         return supplier.get();
+    }
+
+    @Override
+    public String getIndexText() {
+        return indexText;
     }
 
     @Override

--- a/runtime/api/src/main/java/com/asakusafw/dag/api/counter/basic/StandardColumn.java
+++ b/runtime/api/src/main/java/com/asakusafw/dag/api/counter/basic/StandardColumn.java
@@ -68,4 +68,9 @@ public enum StandardColumn implements CounterGroup.Column {
     public String getDescription() {
         return description;
     }
+
+    @Override
+    public String getIndexText() {
+        return String.format("STANDARD.%04d", ordinal()); //$NON-NLS-1$
+    }
 }

--- a/runtime/directio/src/main/java/com/asakusafw/dag/runtime/directio/DirectFileCounterGroup.java
+++ b/runtime/directio/src/main/java/com/asakusafw/dag/runtime/directio/DirectFileCounterGroup.java
@@ -38,6 +38,7 @@ public class DirectFileCounterGroup implements CounterGroup {
             "Direct I/O file input",
             Scope.GRAPH,
             Arrays.asList(StandardColumn.INPUT_FILE_SIZE, StandardColumn.INPUT_RECORD),
+            "directio-0-input", //$NON-NLS-1$
             () -> new DirectFileCounterGroup(StandardColumn.INPUT_FILE_SIZE, StandardColumn.INPUT_RECORD));
 
     /**
@@ -47,6 +48,7 @@ public class DirectFileCounterGroup implements CounterGroup {
             "Direct I/O file output",
             Scope.GRAPH,
             Arrays.asList(StandardColumn.OUTPUT_FILE_SIZE, StandardColumn.OUTPUT_RECORD),
+            "directio-1-output", //$NON-NLS-1$
             () -> new DirectFileCounterGroup(StandardColumn.OUTPUT_FILE_SIZE, StandardColumn.OUTPUT_RECORD));
 
     private final Map<Column, Counter> counters = new LinkedHashMap<>();

--- a/runtime/extension/counter/src/main/java/com/asakusafw/dag/extension/counter/CounterRepositorySupportExtension.java
+++ b/runtime/extension/counter/src/main/java/com/asakusafw/dag/extension/counter/CounterRepositorySupportExtension.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import com.asakusafw.dag.api.counter.CounterGroup.Category;
 import com.asakusafw.dag.api.counter.CounterGroup.Column;
+import com.asakusafw.dag.api.counter.CounterGroup.Element;
 import com.asakusafw.dag.api.counter.CounterGroup.Scope;
 import com.asakusafw.dag.api.counter.CounterRepository;
 import com.asakusafw.dag.api.counter.basic.BasicCounterRepository;
@@ -80,24 +81,24 @@ public class CounterRepositorySupportExtension implements ProcessorContextExtens
                                 CounterRepository.Entry::getCounters,
                                 CounterRepository::merge,
                                 TreeMap::new)));
-        categories.forEach((category, members) -> {
+        forEachElement(categories, (category, members) -> {
             LOG.info(String.format("%s: %,d entries", category.getDescription(), members.size()));
             Map<Column, Long> total = new LinkedHashMap<>();
             members.forEach((item, counters) -> {
                 LOG.info(String.format("  %s:", item));
-                forEachColumns(counters, (column, value) -> {
+                forEachElement(counters, (column, value) -> {
                     LOG.info(String.format("    %s: %,d", column.getDescription(), value));
                 });
                 CounterRepository.mergeInto(counters, total);
             });
             LOG.info(String.format("  %s:", "(TOTAL)"));
-            forEachColumns(total, (column, value) -> {
+            forEachElement(total, (column, value) -> {
                 LOG.info(String.format("    %s: %,d", column.getDescription(), value));
             });
         });
     }
 
-    private static <T> void forEachColumns(Map<Column, T> map, BiConsumer<Column, T> action) {
+    private static <K extends Element, V> void forEachElement(Map<K, V> map, BiConsumer<K, V> action) {
         map.entrySet().stream()
             .map(Tuple::of)
             .sorted((a, b) -> a.left().getIndexText().compareTo(b.left().getIndexText()))

--- a/runtime/extension/counter/src/main/java/com/asakusafw/dag/extension/counter/CounterRepositorySupportExtension.java
+++ b/runtime/extension/counter/src/main/java/com/asakusafw/dag/extension/counter/CounterRepositorySupportExtension.java
@@ -18,6 +18,7 @@ package com.asakusafw.dag.extension.counter;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -31,6 +32,7 @@ import com.asakusafw.dag.api.counter.basic.BasicCounterRepository;
 import com.asakusafw.dag.api.processor.ProcessorContext;
 import com.asakusafw.dag.api.processor.extension.ProcessorContextExtension;
 import com.asakusafw.dag.utils.common.InterruptibleIo;
+import com.asakusafw.dag.utils.common.Tuple;
 
 /**
  * Enables {@link CounterRepository}.
@@ -83,15 +85,22 @@ public class CounterRepositorySupportExtension implements ProcessorContextExtens
             Map<Column, Long> total = new LinkedHashMap<>();
             members.forEach((item, counters) -> {
                 LOG.info(String.format("  %s:", item));
-                counters.forEach((column, value) -> {
+                forEachColumns(counters, (column, value) -> {
                     LOG.info(String.format("    %s: %,d", column.getDescription(), value));
                 });
                 CounterRepository.mergeInto(counters, total);
             });
             LOG.info(String.format("  %s:", "(TOTAL)"));
-            total.forEach((column, value) -> {
+            forEachColumns(total, (column, value) -> {
                 LOG.info(String.format("    %s: %,d", column.getDescription(), value));
             });
         });
+    }
+
+    private static <T> void forEachColumns(Map<Column, T> map, BiConsumer<Column, T> action) {
+        map.entrySet().stream()
+            .map(Tuple::of)
+            .sorted((a, b) -> a.left().getIndexText().compareTo(b.left().getIndexText()))
+            .forEachOrdered(t -> action.accept(t.left(), t.right()));
     }
 }

--- a/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/operation/JdbcCounterGroup.java
+++ b/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/operation/JdbcCounterGroup.java
@@ -37,6 +37,7 @@ public final class JdbcCounterGroup extends AbstractCounterGroup {
             "JDBC input",
             Scope.GRAPH,
             Collections.singletonList(StandardColumn.INPUT_RECORD),
+            "jdbc-0-input", //$NON-NLS-1$
             () -> new JdbcCounterGroup(StandardColumn.INPUT_RECORD));
 
     /**
@@ -46,6 +47,7 @@ public final class JdbcCounterGroup extends AbstractCounterGroup {
             "JDBC output",
             Scope.GRAPH,
             Collections.singletonList(StandardColumn.OUTPUT_RECORD),
+            "jdbc-1-output", //$NON-NLS-1$
             () -> new JdbcCounterGroup(StandardColumn.OUTPUT_RECORD));
 
     private final LongAdder counter;


### PR DESCRIPTION
## Summary

This PR draws up the counter report entries in the same order each time.
## Background, Problem or Goal of the patch

The counter reports (in Asakusa on M3BP) which shows statistics of Direct I/O or WindGate direct mode, are not sorted in the latest implementation.
## Design of the fix, or a new feature

This ensures to draws up the counter categories in the following order:
1. Direct file inputs
   1. record count
   2. file size
2. Direct file outputs
   1. record count
   2. file size
3. WindGate JDBC direct inputs
   1. record count
4. WindGate JDBC direct outputs
   1. record count
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
